### PR TITLE
chore: harden Renovate config to best-practices

### DIFF
--- a/gotest/Makefile
+++ b/gotest/Makefile
@@ -18,7 +18,10 @@ KUBECTL           := kubectl --context=kind-$(KIND_CLUSTER_NAME)
 MANIFEST          := ../k8s/postgresql/authentik-postgresql.yml
 KIND_CONFIG       := ../k8s/kind-config.yaml
 AUTHENTIK_NS      := default
-# renovate: datasource=github-releases depName=kubernetes-sigs/cloud-provider-kind extractVersion=^v(?<version>.*)$
+# Track the REGISTRY image (the consumed sink), not the GitHub release: registry.k8s.io
+# image promotion lags the upstream release, so github-releases proposes un-pullable tags.
+# The `# renovate:` line MUST stay immediately above the constant (customManager adjacency).
+# renovate: datasource=docker depName=registry.k8s.io/cloud-provider-kind/cloud-controller-manager extractVersion=^v(?<version>.*)$
 CLOUD_PROVIDER_KIND_VERSION := 0.11.1
 # renovate: datasource=docker depName=kindest/node
 KIND_NODE_IMAGE := kindest/node:v1.36.1@sha256:3489c7674813ba5d8b1a9977baea8a6e553784dab7b84759d1014dbd78f7ebd5

--- a/k8s/postgresql/authentik-postgresql.yml
+++ b/k8s/postgresql/authentik-postgresql.yml
@@ -585,7 +585,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
         - name: server
-          image: ghcr.io/goauthentik/server:2026.5.0
+          image: ghcr.io/goauthentik/server:2026.5
           imagePullPolicy: IfNotPresent
           args:
             - server
@@ -697,7 +697,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
         - name: worker
-          image: ghcr.io/goauthentik/server:2026.5.0
+          image: ghcr.io/goauthentik/server:2026.5
           imagePullPolicy: IfNotPresent
           args:
             - worker

--- a/renovate.json
+++ b/renovate.json
@@ -1,14 +1,34 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:recommended"],
+  "extends": [
+    "config:best-practices",
+    ":semanticCommitType(chore)"
+  ],
   "timezone": "UTC",
+  "enabledManagers": [
+    "gomod",
+    "github-actions",
+    "dockerfile",
+    "docker-compose",
+    "kubernetes",
+    "mise",
+    "custom.regex"
+  ],
+  "commitMessagePrefix": "chore(all): ",
+  "commitMessageAction": "update",
+  "commitBody": "Signed-off-by: Renovate Bot <bot@renovateapp.com>",
+  "labels": ["dependencies"],
+  "prConcurrentLimit": 50,
+  "prHourlyLimit": 0,
+  "automerge": false,
+  "postUpdateOptions": ["gomodTidy"],
   "kubernetes": {
     "managerFilePatterns": ["/k8s/.+\\.ya?ml$/"]
   },
   "customManagers": [
     {
       "customType": "regex",
-      "description": "Makefile tool-version constants (e.g. CLOUD_PROVIDER_KIND_VERSION) pinned via # renovate: comments. currentValue must start with a digit so image refs are handled by the dedicated manager below.",
+      "description": "Makefile tool-version constants pinned via # renovate: comments. currentValue must start with a digit so image refs are handled by the dedicated manager below.",
       "managerFilePatterns": ["/(^|/)Makefile$/"],
       "matchStrings": [
         "# renovate: datasource=(?<datasource>\\S+) depName=(?<depName>\\S+)(?: versioning=(?<versioning>\\S+))?(?: extractVersion=(?<extractVersion>\\S+))?\\s+[A-Z0-9_]+\\s*:?=\\s*(?<currentValue>[0-9][^\\s@]*)"
@@ -32,22 +52,78 @@
       ]
     }
   ],
+  "vulnerabilityAlerts": {
+    "labels": ["security"],
+    "minimumReleaseAge": "0 days"
+  },
   "packageRules": [
     {
+      "description": "Wait 3 days before opening major-update PRs (stability buffer).",
+      "matchUpdateTypes": ["major"],
+      "minimumReleaseAge": "3 days"
+    },
+    {
+      "description": "Group GitHub Actions into one PR.",
+      "matchManagers": ["github-actions"],
+      "groupName": "GitHub Actions"
+    },
+    {
+      "description": "Do not track the experimental, known-broken CockroachDB backend. CockroachDB lacks pg_advisory_lock() which Authentik's Django migrations require, so these manifests are intentionally frozen (and their stale Authentik 2024.4 image pins would otherwise collide with the live 2026.5 pins in the Authentik server group, causing Renovate's dedup to drop one side).",
+      "matchFileNames": ["k8s/cockroachdb/**"],
+      "enabled": false
+    },
+    {
       "description": "Group the Go toolchain across go.mod, .mise.toml and the Dockerfile so they bump as a unit (paired with `make check-toolchain-alignment`).",
-      "groupName": "go toolchain",
       "matchManagers": ["gomod", "mise", "dockerfile"],
-      "matchPackageNames": ["go", "golang"]
+      "matchPackageNames": ["go", "golang"],
+      "groupName": "go toolchain"
+    },
+    {
+      "description": "Bump the go directive in go.mod to the latest patch rather than widening the range.",
+      "matchManagers": ["gomod"],
+      "matchDepNames": ["go"],
+      "rangeStrategy": "bump"
     },
     {
       "description": "Group the local Kubernetes toolchain (kind / kubectl / node image / cloud-provider-kind).",
-      "groupName": "kubernetes toolchain",
       "matchPackageNames": [
         "kubernetes-sigs/kind",
         "kubernetes/kubectl",
-        "kubernetes-sigs/cloud-provider-kind",
+        "registry.k8s.io/cloud-provider-kind/cloud-controller-manager",
         "kindest/node"
-      ]
+      ],
+      "groupName": "kubernetes toolchain"
+    },
+    {
+      "description": "Hold mise aqua/github-tags tools 3 days so the upstream GitHub Release artifacts the aqua backend installs are published before the PR opens (avoids the tag-before-publish 404).",
+      "matchManagers": ["mise"],
+      "matchDatasources": ["github-tags"],
+      "minimumReleaseAge": "3 days"
+    },
+    {
+      "description": "Lock kubectl to the cluster node's minor line (kindest/node v1.36.x). CI runs no live e2e, so it cannot catch kubectl<->apiserver skew — this constraint is the only guard. Matches by packageName (the mise aqua depName is `aqua:kubernetes/kubectl`, but packageName resolves to `kubernetes/kubectl`). Bump it together with kind + kindest/node when the cluster moves to a new minor.",
+      "matchManagers": ["mise"],
+      "matchPackageNames": ["kubernetes/kubectl"],
+      "allowedVersions": "/^1\\.36\\./"
+    },
+    {
+      "description": "Custom.regex docker pins (env-file AUTHENTIK_TAG, Makefile cloud-provider-kind) are bare tags/versions, not pullable image refs, so docker:pinDigests cannot render a write for them — disable it. Production-runtime pins via the built-in dockerfile/docker-compose/kubernetes managers keep their digests.",
+      "matchManagers": ["custom.regex"],
+      "matchDatasources": ["docker"],
+      "pinDigests": false
+    },
+    {
+      "description": "KIND_NODE_IMAGE already carries a digest; suppress standalone digest-refresh updates so they don't collide with and silently drop the version bump (which brings its own fresh digest).",
+      "matchPackageNames": ["kindest/node"],
+      "matchUpdateTypes": ["digest"],
+      "enabled": false
+    },
+    {
+      "description": "Group the Authentik server image across the k8s manifest (kubernetes manager) and compose .env (custom.regex). Both pin the rolling `2026.5` tag; pinDigests:false keeps them symmetric (the env tag cannot carry a digest) so dedup doesn't drop one side.",
+      "matchManagers": ["kubernetes", "custom.regex"],
+      "matchPackageNames": ["ghcr.io/goauthentik/server"],
+      "groupName": "Authentik server",
+      "pinDigests": false
     }
   ]
 }


### PR DESCRIPTION
Upgrades the Renovate config from `config:recommended` to `config:best-practices` and fixes several tracking bugs found during a `/renovate` review.

## Highlights
- **best-practices preset** + `:semanticCommitType(chore)`, explicit `enabledManagers`, `chore(all):` prefix, sign-off, labels
- **vulnerabilityAlerts** fast-track (Dependabot alerts enabled on the repo)
- **3-day buffers** for majors AND mise aqua/github-tags tools (tag-before-publish 404 guard)
- GitHub Actions grouped; `gomodTidy`; go.mod `rangeStrategy: bump`
- **automerge OFF** (deliberate): CI runs only build + mock tests, no live Authentik e2e — green CI doesn't prove a bump works (we just hit client/server skew)

## Correctness fixes
- **cloud-provider-kind** now tracked via `datasource=docker` against the `registry.k8s.io` image (the consumed sink). `github-releases` lags image promotion → un-pullable tags.
- **Authentik server image** aligned to the rolling `2026.5` tag in k8s + grouped with the compose `.env` pin so cross-manager dedup can't silently drop one side.
- `pinDigests:false` for bare custom.regex docker pins; suppress kindest/node digest-refresh collisions; lock kubectl to the cluster's `1.36` line (no e2e in CI to catch apiserver skew).
- Stop tracking the experimental, known-broken **CockroachDB** backend (frozen; its stale 2024.4 pins were colliding with 2026.5).

Validated with `renovate@latest --platform=local` — config clean, all 7 managers active, regex manager extracts all 3 custom pins.