### PR TITLE
chore: rename binary to provisioner; stop pinning golang builder digest

### DIFF
--- a/provisioner/Dockerfile
+++ b/provisioner/Dockerfile
@@ -15,9 +15,9 @@ RUN go mod download
 COPY . .
 # CGO disabled → fully static binary for the distroless/static base.
 # Dependencies are pure Go (goauthentik client + go-openapi), so this is safe.
-RUN CGO_ENABLED=0 GOOS=linux go build -trimpath -ldflags="-s -w" -o /out/authentik-poc .
+RUN CGO_ENABLED=0 GOOS=linux go build -trimpath -ldflags="-s -w" -o /out/provisioner .
 
 FROM gcr.io/distroless/static-debian12:nonroot@sha256:d093aa3e30dbadd3efe1310db061a14da60299baff8450a17fe0ccc514a16639
-COPY --from=build /out/authentik-poc /usr/local/bin/authentik-poc
+COPY --from=build /out/provisioner /usr/local/bin/provisioner
 USER nonroot:nonroot
-ENTRYPOINT ["/usr/local/bin/authentik-poc"]
+ENTRYPOINT ["/usr/local/bin/provisioner"]

--- a/provisioner/Makefile
+++ b/provisioner/Makefile
@@ -1,10 +1,10 @@
 .DEFAULT_GOAL := help
 
-APP_NAME := authentik-poc
+APP_NAME := provisioner
 GOFLAGS  ?= -mod=mod
 
 # --- Image ---
-IMAGE_REPO ?= authentik-poc
+IMAGE_REPO ?= provisioner
 IMAGE_TAG  ?= dev
 IMAGE      := $(IMAGE_REPO):$(IMAGE_TAG)
 

--- a/renovate.json
+++ b/renovate.json
@@ -113,6 +113,12 @@
       "pinDigests": false
     },
     {
+      "description": "Do NOT digest-pin the golang BUILDER base. The digest folds onto `ARG GO_VERSION=1.26.4` (-> `1.26.4@sha256:...`), which breaks `make check-toolchain-alignment` (it awk-extracts the ARG and compares to go.mod's bare version) and would collide with the go-toolchain group's version bumps. The builder digest never reaches the distroless runtime image, so it adds no supply-chain value. The runtime base (distroless) keeps its digest pin.",
+      "matchManagers": ["dockerfile"],
+      "matchDepNames": ["golang"],
+      "pinDigests": false
+    },
+    {
       "description": "KIND_NODE_IMAGE already carries a digest; suppress standalone digest-refresh updates so they don't collide with and silently drop the version bump (which brings its own fresh digest).",
       "matchPackageNames": ["kindest/node"],
       "matchUpdateTypes": ["digest"],


### PR DESCRIPTION
- Rename the built binary `authentik-poc` -> `provisioner` (Dockerfile build output, COPY, ENTRYPOINT; Makefile `APP_NAME` + `IMAGE_REPO`) so it matches the dir/module name.
- Add a Renovate rule (`matchManagers=dockerfile, matchDepNames=golang, pinDigests=false`) so `docker:pinDigests` can't fold a digest onto `ARG GO_VERSION` — that broke `make check-toolchain-alignment` (closed PR #14). The distroless **runtime** base keeps its digest pin.

Image build verified locally (`provisioner:dev`).