### PR TITLE
docs: descriptive README header (About-aligned) + mermaid-lint gate

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 [![CI](https://github.com/AndriyKalashnykov/authentik-k8s/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/AndriyKalashnykov/authentik-k8s/actions/workflows/ci.yml)
+[![Hits](https://hits.sh/github.com/AndriyKalashnykov/authentik-k8s.svg?view=today-total&style=plastic)](https://hits.sh/github.com/AndriyKalashnykov/authentik-k8s/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-brightgreen.svg)](https://opensource.org/licenses/MIT)
 [![Renovate enabled](https://img.shields.io/badge/renovate-enabled-brightgreen.svg)](https://renovatebot.com)
 [![Go](https://img.shields.io/github/go-mod/go-version/AndriyKalashnykov/authentik-k8s?filename=provisioner%2Fgo.mod)](https://github.com/AndriyKalashnykov/authentik-k8s/blob/main/provisioner/go.mod)
-[![Hits](https://hits.sh/github.com/AndriyKalashnykov/authentik-k8s.svg?view=today-total&style=plastic)](https://hits.sh/github.com/AndriyKalashnykov/authentik-k8s/)
 
-# authentik-k8s
+# Authentik Provisioning with the Go Client
 
 *Provision Authentik — groups, users, passwords, OAuth tokens — programmatically with the Go client. Deploy on Kubernetes (KinD) or Docker Compose.*
 

--- a/provisioner/Makefile
+++ b/provisioner/Makefile
@@ -26,6 +26,11 @@ CLOUD_PROVIDER_KIND_VERSION := 0.11.1
 # renovate: datasource=docker depName=kindest/node
 KIND_NODE_IMAGE := kindest/node:v1.36.1@sha256:3489c7674813ba5d8b1a9977baea8a6e553784dab7b84759d1014dbd78f7ebd5
 
+# mermaid-cli is a docker-only tool (no mise backend); pinned here, Renovate-tracked
+# via the Makefile customManager. Used by `mermaid-lint` to validate README diagrams.
+# renovate: datasource=docker depName=minlag/mermaid-cli
+MERMAID_CLI_VERSION := 11.15.0
+
 # Make recipes don't source shell rc files; put mise's shims dir on PATH so
 # every mise-managed tool (go, golangci-lint, govulncheck, hadolint, kind,
 # kubectl) resolves inside recipes.
@@ -94,8 +99,28 @@ lint-docker: deps
 vulncheck: deps
 	@govulncheck ./...
 
-#static-check: @ Composite quality gate (alignment + lint + hadolint + vulncheck)
-static-check: deps check-toolchain-alignment lint lint-docker vulncheck
+#mermaid-lint: @ Validate README/CLAUDE Mermaid diagrams render cleanly (minlag/mermaid-cli)
+mermaid-lint:
+	@command -v docker >/dev/null 2>&1 || { echo "ERROR: docker is required for mermaid-lint"; exit 1; }
+	@set -e; \
+	MD_FILES=$$(cd .. && grep -lF '```mermaid' README.md CLAUDE.md 2>/dev/null || true); \
+	if [ -z "$$MD_FILES" ]; then echo "No Mermaid blocks found — skipping."; exit 0; fi; \
+	IMAGE=minlag/mermaid-cli:$(MERMAID_CLI_VERSION); \
+	FAILED=0; \
+	for md in $$MD_FILES; do \
+		echo "Validating Mermaid blocks in $$md..."; \
+		if docker run --rm -v "$(PWD)/..:/data:ro" "$$IMAGE" \
+			-i "/data/$$md" -o "/tmp/$$(basename $$md .md).svg" >/tmp/mmlint.log 2>&1; then \
+			echo "  OK"; \
+		else \
+			echo "  PARSE ERROR in $$md:"; cat /tmp/mmlint.log; FAILED=1; \
+		fi; \
+	done; \
+	[ $$FAILED -eq 0 ] || { echo "mermaid-lint: FAILED"; exit 1; }
+	@echo "mermaid-lint: OK"
+
+#static-check: @ Composite quality gate (alignment + lint + hadolint + mermaid + vulncheck)
+static-check: deps check-toolchain-alignment lint lint-docker mermaid-lint vulncheck
 	@echo "Static check passed."
 
 #image-build: @ Build the POC container image
@@ -231,6 +256,6 @@ ci: static-check test build
 	@echo "Local CI pipeline passed."
 
 .PHONY: help deps deps-check check-toolchain-alignment build run test lint lint-docker \
-	vulncheck static-check image-build image-run update clean renovate-validate \
+	vulncheck mermaid-lint static-check image-build image-run update clean renovate-validate \
 	compose-up compose-down compose-logs e2e-compose deps-kind kind-create kind-deploy \
 	e2e kind-destroy kind-up kind-down ci


### PR DESCRIPTION
`/readme` review fixes.

## Header + About alignment
- H1 `# authentik-k8s` (the repo slug — a `/readme` anti-pattern) → **`# Authentik Provisioning with the Go Client`**.
- Set the (previously empty) **GitHub About** to `Provision Authentik groups, users, and OAuth tokens programmatically with its Go client — deploy the IdP on Kubernetes (KinD) or Docker Compose`, aligned with the H1 (shared subject nouns: Authentik / Go client / Kubernetes+Compose).
- Badges reordered to canonical **CI, Hits, License, Renovate** (+Go).

## mermaid-lint gate (CRITICAL — /readme 2a)
README has 2 Mermaid blocks but no validation gate; a broken block silently breaks GitHub homepage rendering. Added `MERMAID_CLI_VERSION` (Renovate-tracked) + a `mermaid-lint` target (minlag/mermaid-cli) wired into `make static-check`. Docker is already a core dep here, so no new dependency. `make mermaid-lint` → OK; `renovate --platform=local` clean (regex depCount 3→4).