### PR TITLE
chore: remove last qleet reference + fix CLAUDE.md staleness

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -94,19 +94,33 @@ cp compose/.env.example  compose/.env    # Compose stack: PG_*, AUTHENTIK_SECRET
 
 - **POC flow** (`CreateGroupsAndUsers`, called 4× for org-01/org-02 × admin/user): create group → create user in group → set password → create API token → retrieve the Authentik-generated key → overwrite it with a known key → re-create an API client *as that user* with the known token → call `MeRetrieveUser` to read the user's groups. The final step demonstrates a non-privileged token can read its own group membership.
 
-- **Manifests are committed artifacts generated from `values.yml`** — but with **two intentional hand-edits**: (1) the `AUTHENTIK_BOOTSTRAP_PASSWORD`/`AUTHENTIK_BOOTSTRAP_TOKEN` env on server+worker; (2) the PostgreSQL and Redis workloads were swapped from the chart's **Bitnami subchart images (removed from Docker Hub in 2025)** to **OSS Deployments** — `postgres:18-alpine` and `valkey/valkey:8-alpine` (Valkey = the BSD/Linux-Foundation Redis fork). The postgres Deployment sets `PGDATA=/var/lib/postgresql/data/pgdata` (an explicit subdir), which keeps the postgres:18+ image — whose default data dir relocated to `/var/lib/postgresql` — working with the existing `/var/lib/postgresql/data` mount (the compose stack, which has no explicit `PGDATA`, instead mounts the volume at `/var/lib/postgresql`). They keep the original Service selectors/ports and read DB creds from the `authentik` Secret, so `authentik-server` connects unchanged. **Regenerating from the chart reintroduces Bitnami** — re-apply the OSS swap after any `helm template` (or disable the chart's bundled `postgresql`/`redis` and point Authentik at the OSS workloads). A few now-unused Bitnami `ConfigMap`s (redis-scripts/health/config, pg-extended-config) remain as harmless dead config.
+- **Manifests are committed artifacts generated from `values.yml`** — but with **two intentional hand-edits**: (1) the `AUTHENTIK_BOOTSTRAP_PASSWORD`/`AUTHENTIK_BOOTSTRAP_TOKEN` env on server+worker; (2) the PostgreSQL and Redis workloads were swapped from the chart's **Bitnami subchart images (removed from Docker Hub in 2025)** to **OSS Deployments** — `postgres:18-alpine` and `valkey/valkey:9-alpine` (Valkey = the BSD/Linux-Foundation Redis fork). The postgres Deployment sets `PGDATA=/var/lib/postgresql/data/pgdata` (an explicit subdir), which keeps the postgres:18+ image — whose default data dir relocated to `/var/lib/postgresql` — working with the existing `/var/lib/postgresql/data` mount (the compose stack, which has no explicit `PGDATA`, instead mounts the volume at `/var/lib/postgresql`). They keep the original Service selectors/ports and read DB creds from the `authentik` Secret, so `authentik-server` connects unchanged. **Regenerating from the chart reintroduces Bitnami** — re-apply the OSS swap after any `helm template` (or disable the chart's bundled `postgresql`/`redis` and point Authentik at the OSS workloads). A few now-unused Bitnami `ConfigMap`s (redis-scripts/health/config, pg-extended-config) remain as harmless dead config.
 
-- **Namespace mismatch between manifests and the deploy script (real bug).** Every resource in `k8s/postgresql/authentik-postgresql.yml` is pinned to `namespace: "default"`, so `kubectl apply -f` lands them in `default`. But `deploy-authentik-k8s.sh` then runs its `patch`/`wait` against `-n threeport-api` (empty). When touching the k8s deploy path, reconcile these two — don't propagate `threeport-api`.
+- **Namespace is `default` end-to-end.** Every resource in `k8s/postgresql/authentik-postgresql.yml` is pinned to `namespace: "default"`, and the `provisioner/` Makefile deploy path (`kind-deploy`) uses `AUTHENTIK_NS := default` — they match. (A former standalone `deploy-authentik-k8s.sh` that patched/waited against `-n threeport-api` was removed; the Makefile is the only deploy path now.)
 
 ## Conventions
 
 - Config is externalized to env vars with fallback defaults (no hardcoded hosts/ports/secrets); see the Environment configuration section. Renovate tracks every pinned version (`renovate.json`); validate with `make renovate-validate`.
 - The client library takes pointers for optional request fields; use the `util.*ToPointer` helpers rather than inlining `&`.
-- **CI**: `.github/workflows/ci.yml` runs `make static-check` + `make build` + `make test` via `jdx/mise-action` (toolchain from `provisioner/.mise.toml`). The Go project is in `provisioner/`, so jobs set `working-directory: provisioner`. A `dorny/paths-filter` `changes` job gates the heavy jobs on `provisioner/**`/`.github/workflows/**`/`CLAUDE.md` edits — doc/k8s/compose/scripts changes skip CI; a `ci-pass` job aggregates results. No tags/publish/e2e (the POC needs a live Authentik instance). No secrets required.
+- **CI**: `.github/workflows/ci.yml` runs `make static-check` + `make build` + `make test` via `jdx/mise-action` (toolchain from `provisioner/.mise.toml`). The Go project is in `provisioner/`, so jobs set `working-directory: provisioner`. A `dorny/paths-filter` `changes` job gates the heavy jobs on `provisioner/**`/`.github/workflows/**`/`CLAUDE.md` edits — doc/k8s/compose changes skip CI; a `ci-pass` job aggregates results. No tags/publish/e2e (the POC needs a live Authentik instance). No secrets required.
 - The local quality gate (`provisioner/Makefile` → `make ci`: golangci-lint + govulncheck + go-mod-tidy + toolchain-alignment) mirrors CI. `.golangci.yml` runs the standard linters; gosec is intentionally omitted (the POC hardcodes test tokens and skips TLS verify by design — documented in `.golangci.yml`).
 - **Test layers**:
   - *Unit + hermetic httptest contracts* (`make test`, no infra): `internal/authentik` (100%) — `CreateConfiguration` auth-header contract + httptest contracts for every `CoreApi` wrapper at the real `/api/v3/...` paths; `internal/util` (87.5%); `main` (66%) — `CreateGroupsAndUsers` whole-flow vs a mock Authentik (`main_test.go`). `CreateGroupsAndUsers` returns `error` (not `log.Panicf`) so the flow is testable.
   - *Live e2e* (`e2e_test.go`, build tag `e2e`) — drives the full flow against a real Authentik and verifies persistence with the admin + the created user's token. Two ways to run it: `make e2e-compose` (Authentik via Docker Compose — lightweight) or `make e2e` (KinD + cloud-provider-kind — full cluster). Both read `AUTHENTIK_E2E_*` env and self-tear-down. Excluded from `make test`.
+
+## Skills
+
+Infrastructure files in this repo map to these maintenance skills — run the matching skill when editing the file:
+
+| File | Skill |
+|------|-------|
+| `provisioner/Makefile` | `/makefile` |
+| `.github/workflows/ci.yml` | `/ci-workflow` |
+| `renovate.json` | `/renovate` |
+| `README.md` | `/readme` |
+| `CLAUDE.md` | `/claude` |
+
+When spawning subagents to work on any of the above, always pass the relevant skill's full conventions into the agent prompt — agents cannot read skill files themselves.
 
 ## Upgrade Backlog
 

--- a/provisioner/internal/util/utils.go
+++ b/provisioner/internal/util/utils.go
@@ -29,15 +29,3 @@ func BoolToPointer(in bool) *bool {
 func StringToPointer(in string) *string {
 	return &in
 }
-
-//// get user's Groups (requires special permissions like Superuser etc.)
-//pl, resp, err := authentik.ListUser(ctx, qleetctlApiClient, QleetctlUser)
-//if err != nil {
-//log.Panicf("error: %v", err)
-//}
-//if resp != nil {
-//users := pl.GetResults()
-//if pl != nil && len(pl.Results) > 0 {
-//log.Printf("User Groups: %v", users[0].Groups)
-//}
-//}

--- a/provisioner/main.go
+++ b/provisioner/main.go
@@ -27,6 +27,31 @@ const (
 	defaultOrg2UserToken  = "svkH90FMYlnXPA5JHxePVQkozTjXReT6rsdQ2BXedwI5mtrFYR5mfrunMt4B"
 )
 
+// Demo naming convention. Group / user / token-identifier names are derived
+// from the org name (see deriveNames + .env.example); these are the fixed
+// role/group segments and join tokens, single-sourced so the scheme lives in
+// exactly one place rather than as inline literals in the provisioning table.
+const (
+	roleAdmin      = "admin"  // user-name segment for the admin user
+	roleUser       = "user"   // user-name segment for the regular user
+	groupAdmins    = "admins" // group-name segment for admins (superusers)
+	groupUsers     = "users"  // group-name segment for regular users
+	nameSep        = "-"      // joins <org> with <role>/<group>
+	tokenSuffix    = "-token" // appended to the user name to form the token identifier
+	userPathPrefix = "orgs/"  // Authentik user `path` prefix, namespaced per org
+)
+
+// deriveNames builds the Authentik object names for one (org, role, group) from
+// the demo naming convention. Pure + exported-to-the-test so the scheme is
+// locked by a unit test rather than only exercised live.
+func deriveNames(org, role, group string) (groupName, userName, tokenIdentifier, userPath string) {
+	groupName = org + nameSep + group
+	userName = org + nameSep + role
+	tokenIdentifier = userName + tokenSuffix
+	userPath = userPathPrefix + org
+	return groupName, userName, tokenIdentifier, userPath
+}
+
 // env returns the value of key, or fallback when unset/empty.
 func env(key, fallback string) string {
 	if v, ok := os.LookupEnv(key); ok && v != "" {
@@ -139,23 +164,20 @@ func main() {
 	// the per-user OAuth token keys are externalized to env.
 	type provision struct {
 		org       string
-		role      string // "admin" | "user"
-		group     string // "admins" | "users"
+		role      string // roleAdmin | roleUser
+		group     string // groupAdmins | groupUsers
 		superuser bool   // admins can log into the Authentik admin UI
 		token     string
 	}
 	requests := []provision{
-		{org1, "admin", "admins", true, env("AUTHENTIK_ORG1_ADMIN_TOKEN", defaultOrg1AdminToken)},
-		{org1, "user", "users", false, env("AUTHENTIK_ORG1_USER_TOKEN", defaultOrg1UserToken)},
-		{org2, "admin", "admins", true, env("AUTHENTIK_ORG2_ADMIN_TOKEN", defaultOrg2AdminToken)},
-		{org2, "user", "users", false, env("AUTHENTIK_ORG2_USER_TOKEN", defaultOrg2UserToken)},
+		{org1, roleAdmin, groupAdmins, true, env("AUTHENTIK_ORG1_ADMIN_TOKEN", defaultOrg1AdminToken)},
+		{org1, roleUser, groupUsers, false, env("AUTHENTIK_ORG1_USER_TOKEN", defaultOrg1UserToken)},
+		{org2, roleAdmin, groupAdmins, true, env("AUTHENTIK_ORG2_ADMIN_TOKEN", defaultOrg2AdminToken)},
+		{org2, roleUser, groupUsers, false, env("AUTHENTIK_ORG2_USER_TOKEN", defaultOrg2UserToken)},
 	}
 
 	for _, r := range requests {
-		groupName := r.org + "-" + r.group
-		userName := r.org + "-" + r.role
-		tokenIdentifier := userName + "-token"
-		userPath := "orgs/" + r.org
+		groupName, userName, tokenIdentifier, userPath := deriveNames(r.org, r.role, r.group)
 		if err := CreateGroupsAndUsers(ctx, scheme, host, bootstrapToken,
 			groupName, r.superuser, userName, userPath, password, tokenIdentifier, r.token); err != nil {
 			log.Fatalf("error: %v", err)

--- a/provisioner/main_test.go
+++ b/provisioner/main_test.go
@@ -90,6 +90,27 @@ func TestCreateGroupsAndUsers_WholePath(t *testing.T) {
 	}
 }
 
+// TestDeriveNames locks the demo naming convention: group/user/token/path are
+// derived from (org, role, group) via the single-sourced naming constants.
+func TestDeriveNames(t *testing.T) {
+	cases := []struct {
+		org, role, group                             string
+		wantGroup, wantUser, wantToken, wantUserPath string
+	}{
+		{"org-01", roleAdmin, groupAdmins, "org-01-admins", "org-01-admin", "org-01-admin-token", "orgs/org-01"},
+		{"org-01", roleUser, groupUsers, "org-01-users", "org-01-user", "org-01-user-token", "orgs/org-01"},
+		{"org-02", roleAdmin, groupAdmins, "org-02-admins", "org-02-admin", "org-02-admin-token", "orgs/org-02"},
+	}
+	for _, c := range cases {
+		g, u, tok, p := deriveNames(c.org, c.role, c.group)
+		if g != c.wantGroup || u != c.wantUser || tok != c.wantToken || p != c.wantUserPath {
+			t.Errorf("deriveNames(%q,%q,%q) = (%q,%q,%q,%q), want (%q,%q,%q,%q)",
+				c.org, c.role, c.group, g, u, tok, p,
+				c.wantGroup, c.wantUser, c.wantToken, c.wantUserPath)
+		}
+	}
+}
+
 func writeJSON(w http.ResponseWriter, status int, body string) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(status)


### PR DESCRIPTION
## qleet eradication
- The live Go code is already qleet-free (env-driven `org-01`/`org-02` naming). The only `qleet` left in any text file was a **dead commented-out block** in `provisioner/internal/util/utils.go` (referenced `qleetctlApiClient`/`QleetctlUser`) — removed. `git grep -in qleet` now returns nothing.
- ⚠️ **Screenshots** (`docs/img/*.jpg`) still show the qleet-era Authentik UI. They're binary JPEGs — I can't edit the pixels. They need re-capturing against the current demo data (the POC creates `org-01`/`org-02` groups + `<org>-admin`/`<org>-admins` users). See note below.

## CLAUDE.md staleness (project-review findings)
- `valkey/valkey:8-alpine` → `9-alpine` (the manifest twin my `/upgrade-analysis` caught in the README but missed here).
- Rewrote the obsolete **namespace-mismatch** note — it referenced the deleted `deploy-authentik-k8s.sh`; the Makefile deploy uses `AUTHENTIK_NS=default`, which matches the manifests.
- Added the missing **`## Skills`** section.
- Dropped the stale **'scripts'** mention from the CI paths-filter description.