### PR TITLE
ci: trivy-fs + gitleaks gates, CI e2e job, pin compose redis

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ permissions:
 
 jobs:
   # Cheap path detector: only Go-project or workflow changes run CI.
-  # Doc / k8s / compose / scripts changes skip the heavy jobs (positive
+  # Doc / k8s / compose changes skip the heavy jobs (positive
   # allow-list — the code paths here are enumerable). CLAUDE.md is project
   # config, not docs, so it counts as code.
   changes:
@@ -94,9 +94,29 @@ jobs:
       - name: Test
         run: make test
 
+  # Live e2e: stand up Authentik via Docker Compose, provision + verify with the
+  # Go POC, tear down. No secrets needed (demo bootstrap token from .env.example).
+  e2e:
+    needs: [changes, build, test]
+    if: ${{ !failure() && !cancelled() && needs.changes.outputs.code == 'true' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    defaults:
+      run:
+        working-directory: provisioner
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      - uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d # v4.2.0
+        with:
+          install: true
+          cache: true
+          working_directory: provisioner
+      - name: E2E (Authentik via Docker Compose)
+        run: make e2e-compose
+
   ci-pass:
     if: always()
-    needs: [changes, static-check, build, test]
+    needs: [changes, static-check, build, test, e2e]
     runs-on: ubuntu-latest
     timeout-minutes: 2
     steps:

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,26 @@
+# gitleaks config for the `secrets` Make target (scans the CURRENT working tree:
+# `gitleaks detect --no-git`). This repo is a POC whose .env.example / k8s
+# manifests / main.go fallback consts intentionally ship DEMO credentials
+# (documented as "rotate for real use"). They are allowlisted below so the gate
+# still catches a REAL accidental leak anywhere else (code, scripts, compose).
+[extend]
+useDefault = true
+
+[allowlist]
+description = "Intentional committed demo credentials (rotate for real deployments)"
+# Whole-file demo-credential sources:
+#  - .env / .env.example: the committed config source-of-truth + local overrides
+#  - k8s/**.y(a)ml: Helm-generated Authentik manifests; the only 'secrets' are the
+#    demo `authentik` Secret and base64 of non-secrets (service names, db names)
+paths = [
+    '''(^|/)\.env(\.example)?$''',
+    '''^k8s/.+\.ya?ml$''',
+]
+# main.go ships the same demo tokens as fallback defaults (mirroring .env.example);
+# allowlist the exact values so the rest of the Go code is still scanned.
+regexes = [
+    '''NoMlxBQuYgfu3j19ygGqhjXenAjrJgOfN5naqmSDBUhdLjYqHKze7yyzY07H''',
+    '''ZId4CDEtmHbnuxkJH2ehUzHgYeTmOansuCO0JsTTsZnYB1z9N0WoAutpyH4i''',
+    '''e3qVF1uGTL5DKjglvMKpDYk60X7s89jnbNh9nPEpFYzSgoOHYDSMi0xxYhYr''',
+    '''svkH90FMYlnXPA5JHxePVQkozTjXReT6rsdQ2BXedwI5mtrFYR5mfrunMt4B''',
+]

--- a/compose/docker-compose.yml
+++ b/compose/docker-compose.yml
@@ -25,7 +25,7 @@ services:
     ports:
       - "0.0.0.0:${PG_PORT_HTTP:-5432}:5432"
   redis:
-    image: docker.io/library/redis:alpine@sha256:9d317178eceac8454a2284a9e6df2466b93c745529947f0cd42a0fa9609d7005
+    image: docker.io/library/redis:8-alpine@sha256:9d317178eceac8454a2284a9e6df2466b93c745529947f0cd42a0fa9609d7005
     command: --save 60 1 --loglevel warning
     restart: unless-stopped
     healthcheck:

--- a/provisioner/.mise.toml
+++ b/provisioner/.mise.toml
@@ -11,3 +11,6 @@ go = "1.26.4"
 # container (see Makefile CLOUD_PROVIDER_KIND_VERSION), not a mise tool.
 "aqua:kubernetes-sigs/kind" = "0.32.0"
 "aqua:kubernetes/kubectl" = "1.36.2"
+# Security gates (static-check): filesystem CVE/secret/misconfig scan + secret scan.
+"aqua:aquasecurity/trivy" = "0.71.2"
+"aqua:gitleaks/gitleaks" = "8.30.1"

--- a/provisioner/Makefile
+++ b/provisioner/Makefile
@@ -99,6 +99,14 @@ lint-docker: deps
 vulncheck: deps
 	@govulncheck ./...
 
+#trivy-fs: @ Filesystem CVE scan of dependencies (HIGH/CRITICAL, fixed-only)
+trivy-fs: deps
+	@trivy fs --scanners vuln --severity HIGH,CRITICAL --ignore-unfixed --exit-code 1 --no-progress --quiet ..
+
+#secrets: @ Scan the working tree for leaked secrets (gitleaks; demo creds allowlisted in .gitleaks.toml)
+secrets: deps
+	@cd .. && gitleaks detect --no-git --source . -c .gitleaks.toml --redact --no-banner
+
 #mermaid-lint: @ Validate README/CLAUDE Mermaid diagrams render cleanly (minlag/mermaid-cli)
 mermaid-lint:
 	@command -v docker >/dev/null 2>&1 || { echo "ERROR: docker is required for mermaid-lint"; exit 1; }
@@ -119,8 +127,8 @@ mermaid-lint:
 	[ $$FAILED -eq 0 ] || { echo "mermaid-lint: FAILED"; exit 1; }
 	@echo "mermaid-lint: OK"
 
-#static-check: @ Composite quality gate (alignment + lint + hadolint + mermaid + vulncheck)
-static-check: deps check-toolchain-alignment lint lint-docker mermaid-lint vulncheck
+#static-check: @ Composite quality gate (alignment + lint + hadolint + mermaid + vulncheck + trivy-fs + secrets)
+static-check: deps check-toolchain-alignment lint lint-docker mermaid-lint vulncheck trivy-fs secrets
 	@echo "Static check passed."
 
 #image-build: @ Build the POC container image
@@ -256,6 +264,6 @@ ci: static-check test build
 	@echo "Local CI pipeline passed."
 
 .PHONY: help deps deps-check check-toolchain-alignment build run test lint lint-docker \
-	vulncheck mermaid-lint static-check image-build image-run update clean renovate-validate \
+	vulncheck mermaid-lint trivy-fs secrets static-check image-build image-run update clean renovate-validate \
 	compose-up compose-down compose-logs e2e-compose deps-kind kind-create kind-deploy \
 	e2e kind-destroy kind-up kind-down ci


### PR DESCRIPTION
Foundation half of the approved `/project-review` apply (docs half already landed in #23).

## Security gates (wired into `make static-check`)
- **trivy-fs** — `trivy fs --scanners vuln --severity HIGH,CRITICAL --ignore-unfixed` (deps CVE scan; currently 0).
- **secrets** — `gitleaks detect --no-git` (current tree). `.gitleaks.toml` allowlists the **intentional** committed demo creds: `.env.example` + generated `k8s/*.yml` by path, `main.go` fallback tokens by exact value — so a *real* leak in code/scripts still trips. Current-tree (not full-history, which would re-flag demo creds that live in history forever).
- Tools pinned in `.mise.toml` (`aquasecurity/trivy`, `gitleaks/gitleaks`), Renovate-tracked by the native mise manager.

## CI e2e job
New `e2e` job runs `make e2e-compose` (stands up Authentik via Compose, the Go POC provisions + verifies org-01/org-02, self-tears-down — no secrets needed). `needs: [changes, build, test]`, gated on `code`, wired into `ci-pass`.

## Other
- compose `redis:alpine` → `redis:8-alpine` (same digest) so Renovate version-tracks it.

Verified locally: `make static-check` green end-to-end; `renovate --platform=local` clean; `ci.yml` parses. The CI run here exercises the new e2e job for real.