### PR TITLE
chore: drop obsolete `version: '3.4'` from compose file

### DIFF
--- a/compose/docker-compose.yml
+++ b/compose/docker-compose.yml
@@ -1,6 +1,4 @@
 ---
-version: '3.4'
-
 services:
   postgresql:
     image: docker.io/library/postgres:18-alpine@sha256:1b1689b20d16a014a3d195653381cf2caa75a41a92d93b255a9d6ea29fd353aa


### PR DESCRIPTION
The top-level `version:` key is **obsolete** under the Compose Specification (Compose v2): it is ignored and emits `the attribute version is obsolete, it will be ignored` on every `docker compose` run. Removed it — `docker compose config` now validates clean with no warning.

`3.4` was also not the latest legacy schema (`3.8` was the last `3.x`), but the version field as a whole is deprecated, so the correct fix is removal, not a bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)