### PR TITLE
chore: add docker-compose linter (dclint) to the quality gate

### DIFF
--- a/.dclintrc.yaml
+++ b/.dclintrc.yaml
@@ -1,0 +1,16 @@
+# docker-compose-linter (dclint) config — used by `make compose-lint`
+# (zavoloklom/dclint). Catches obsolete/incorrect Compose config (e.g. the
+# obsolete top-level `version` field, which dclint flags as an ERROR via
+# no-version-field). Run with `--max-warnings 0`, so any enabled warning fails.
+#
+# Two cosmetic rules are disabled because they fight this repo's conventions
+# rather than catching real problems:
+rules:
+  # Pure key-ordering preference. Enforcing it would churn + displace the
+  # load-bearing inline comments in docker-compose.yml (the postgres:18
+  # data-dir relocation note, the worker docker.sock notes).
+  service-keys-order: 0
+  # Misfires on env-externalized ports: our ports are already double-quoted
+  # `"0.0.0.0:${PORT:-5432}:5432"` (required by the parameter-externalization
+  # convention), but dclint still flags them wanting single quotes.
+  require-quotes-in-ports: 0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,10 +20,11 @@ permissions:
 # mise-action reads provisioner/.mise.toml via its own working_directory input.
 
 jobs:
-  # Cheap path detector: only Go-project or workflow changes run CI.
-  # Doc / k8s / compose changes skip the heavy jobs (positive
-  # allow-list — the code paths here are enumerable). CLAUDE.md is project
-  # config, not docs, so it counts as code.
+  # Cheap path detector: only Go-project, workflow, or Compose changes run CI.
+  # Doc / k8s changes skip the heavy jobs (positive allow-list — the code paths
+  # here are enumerable). CLAUDE.md is project config, not docs, so it counts as
+  # code. compose/** + .dclintrc.yaml are included because static-check runs
+  # compose-lint (dclint) and the e2e job exercises the Compose stack.
   changes:
     runs-on: ubuntu-latest
     timeout-minutes: 2
@@ -39,6 +40,8 @@ jobs:
               - 'provisioner/**'
               - '.github/workflows/**'
               - 'CLAUDE.md'
+              - 'compose/**'
+              - '.dclintrc.yaml'
 
   static-check:
     needs: [changes]

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,7 +39,7 @@ make -C provisioner kind-up      # Kubernetes: KinD + cloud-provider-kind, appli
 cd provisioner
 cp .env.example .env   # one-time: per-dev config (gitignored); main.go also has the same fallbacks
 make deps     # install mise (if missing) + pinned Go/golangci-lint/govulncheck/hadolint/kind/kubectl
-make ci       # full local pipeline: static-check (align+lint+hadolint+vulncheck) + test + build
+make ci       # full local pipeline: static-check (align+lint+hadolint+mermaid+compose+vulncheck+trivy-fs+secrets) + test + build
 make run      # run the POC against a running Authentik (sources .env.example then .env)
 make test     # go test ./...  (unit + hermetic httptest contract tests)
 make image-build / image-run   # build/run the POC container (config via --env-file)
@@ -102,7 +102,7 @@ cp compose/.env.example  compose/.env    # Compose stack: PG_*, AUTHENTIK_SECRET
 
 - Config is externalized to env vars with fallback defaults (no hardcoded hosts/ports/secrets); see the Environment configuration section. Renovate tracks every pinned version (`renovate.json`); validate with `make renovate-validate`.
 - The client library takes pointers for optional request fields; use the `util.*ToPointer` helpers rather than inlining `&`.
-- **CI**: `.github/workflows/ci.yml` runs `make static-check` + `make build` + `make test` via `jdx/mise-action` (toolchain from `provisioner/.mise.toml`). The Go project is in `provisioner/`, so jobs set `working-directory: provisioner`. A `dorny/paths-filter` `changes` job gates the heavy jobs on `provisioner/**`/`.github/workflows/**`/`CLAUDE.md` edits — doc/k8s/compose changes skip CI; a `ci-pass` job aggregates results. No tags/publish/e2e (the POC needs a live Authentik instance). No secrets required.
+- **CI**: `.github/workflows/ci.yml` runs `make static-check` + `make build` + `make test` via `jdx/mise-action` (toolchain from `provisioner/.mise.toml`). The Go project is in `provisioner/`, so jobs set `working-directory: provisioner`. A `dorny/paths-filter` `changes` job gates the heavy jobs on `provisioner/**`/`.github/workflows/**`/`CLAUDE.md`/`compose/**`/`.dclintrc.yaml` edits (compose is included so `static-check`'s `compose-lint` + the `e2e` job run on Compose changes) — doc/k8s changes skip CI; a `ci-pass` job aggregates results. No tags/publish/e2e (the POC needs a live Authentik instance). No secrets required.
 - The local quality gate (`provisioner/Makefile` → `make ci`: golangci-lint + govulncheck + go-mod-tidy + toolchain-alignment) mirrors CI. `.golangci.yml` runs the standard linters; gosec is intentionally omitted (the POC hardcodes test tokens and skips TLS verify by design — documented in `.golangci.yml`).
 - **Test layers**:
   - *Unit + hermetic httptest contracts* (`make test`, no infra): `internal/authentik` (100%) — `CreateConfiguration` auth-header contract + httptest contracts for every `CoreApi` wrapper at the real `/api/v3/...` paths; `internal/util` (87.5%); `main` (66%) — `CreateGroupsAndUsers` whole-flow vs a mock Authentik (`main_test.go`). `CreateGroupsAndUsers` returns `error` (not `log.Panicf`) so the flow is testable.

--- a/README.md
+++ b/README.md
@@ -193,7 +193,8 @@ Run `make help` for the full list. Common targets:
 | `make lint` | Run golangci-lint + verify `go.mod`/`go.sum` are tidy |
 | `make lint-docker` | Lint the Dockerfile with hadolint |
 | `make vulncheck` | Scan dependencies with govulncheck |
-| `make static-check` | Composite gate: toolchain alignment + lint + hadolint + vulncheck |
+| `make compose-lint` | Lint the Compose file with dclint (rules in `.dclintrc.yaml`) |
+| `make static-check` | Composite gate: alignment + lint + hadolint + mermaid + compose + vulncheck + trivy-fs + secrets |
 | `make image-build` / `make image-run` | Build / run the distroless container image |
 | `make compose-up` / `make compose-down` | Start / stop the Authentik Compose stack |
 | `make kind-up` / `make kind-down` | Create+deploy / destroy the KinD cluster |

--- a/compose/docker-compose.yml
+++ b/compose/docker-compose.yml
@@ -1,4 +1,6 @@
 ---
+name: authentik
+
 services:
   postgresql:
     image: docker.io/library/postgres:18-alpine@sha256:1b1689b20d16a014a3d195653381cf2caa75a41a92d93b255a9d6ea29fd353aa

--- a/provisioner/Makefile
+++ b/provisioner/Makefile
@@ -31,6 +31,12 @@ KIND_NODE_IMAGE := kindest/node:v1.36.1@sha256:3489c7674813ba5d8b1a9977baea8a6e5
 # renovate: datasource=docker depName=minlag/mermaid-cli
 MERMAID_CLI_VERSION := 11.15.0
 
+# dclint (docker-compose-linter) is a docker-only tool (no mise backend); pinned
+# here, Renovate-tracked via the Makefile customManager. Used by `compose-lint`
+# to validate the Compose file (rule config in repo-root .dclintrc.yaml).
+# renovate: datasource=docker depName=zavoloklom/dclint
+DCLINT_VERSION := 3.1.0
+
 # Make recipes don't source shell rc files; put mise's shims dir on PATH so
 # every mise-managed tool (go, golangci-lint, govulncheck, hadolint, kind,
 # kubectl) resolves inside recipes.
@@ -127,8 +133,15 @@ mermaid-lint:
 	[ $$FAILED -eq 0 ] || { echo "mermaid-lint: FAILED"; exit 1; }
 	@echo "mermaid-lint: OK"
 
-#static-check: @ Composite quality gate (alignment + lint + hadolint + mermaid + vulncheck + trivy-fs + secrets)
-static-check: deps check-toolchain-alignment lint lint-docker mermaid-lint vulncheck trivy-fs secrets
+#compose-lint: @ Lint the Compose file (zavoloklom/dclint; rules in .dclintrc.yaml, --max-warnings 0)
+compose-lint:
+	@command -v docker >/dev/null 2>&1 || { echo "ERROR: docker is required for compose-lint"; exit 1; }
+	@docker run --rm -v "$(PWD)/..:/w:ro" -w /w zavoloklom/dclint:$(DCLINT_VERSION) \
+		--max-warnings 0 compose/docker-compose.yml
+	@echo "compose-lint: OK"
+
+#static-check: @ Composite quality gate (alignment + lint + hadolint + mermaid + compose + vulncheck + trivy-fs + secrets)
+static-check: deps check-toolchain-alignment lint lint-docker mermaid-lint compose-lint vulncheck trivy-fs secrets
 	@echo "Static check passed."
 
 #image-build: @ Build the POC container image
@@ -264,6 +277,6 @@ ci: static-check test build
 	@echo "Local CI pipeline passed."
 
 .PHONY: help deps deps-check check-toolchain-alignment build run test lint lint-docker \
-	vulncheck mermaid-lint trivy-fs secrets static-check image-build image-run update clean renovate-validate \
+	vulncheck mermaid-lint compose-lint trivy-fs secrets static-check image-build image-run update clean renovate-validate \
 	compose-up compose-down compose-logs e2e-compose deps-kind kind-create kind-deploy \
 	e2e kind-destroy kind-up kind-down ci


### PR DESCRIPTION
Adds a dedicated Compose linter so obsolete/incorrect Compose config is caught automatically (follow-up to dropping the obsolete `version` field in #27).

## What
- `make compose-lint` — runs [zavoloklom/dclint](https://github.com/zavoloklom/docker-compose-linter) (Docker, like `mermaid-lint`), wired into `make static-check`.
- `.dclintrc.yaml` — `--max-warnings 0` (strict). Disables two cosmetic rules that fight repo conventions: `service-keys-order` (would churn + displace load-bearing comments) and `require-quotes-in-ports` (misfires on env-externalized ports, which are already quoted).
- `compose/docker-compose.yml` — add `name: authentik` (satisfies `require-project-name-field`; also yields stable `authentik-*` container names). No functional change.
- `ci.yml` — `compose/**` + `.dclintrc.yaml` added to the paths-filter `code` output, so Compose edits run `static-check` (compose-lint) **and** `e2e` (which exercises the Compose stack).
- `DCLINT_VERSION` Renovate-tracked (datasource=docker).

## Verified
- `make static-check` → rc=0 (compose-lint OK alongside the existing gates).
- `no-version-field` is an **error** in dclint — confirmed it fails on an injected `version:`.
- Renovate customManager captures `zavoloklom/dclint=3.1.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)