### PR TITLE
docs: credential source-of-truth + YugabyteDB deep-spike result

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,7 +59,11 @@ helm repo add authentik https://charts.goauthentik.io && helm repo update
 helm template authentik authentik/authentik -f ./k8s/postgresql/values.yml > ./k8s/postgresql/authentik-postgresql.yml
 ```
 
-Default admin login (both deployments): `akadmin` / `Authentik01234567890!`.
+Default admin login: `akadmin` (Authentik's fixed bootstrap admin user). The
+password is **not** restated here — it is the `AUTHENTIK_BOOTSTRAP_PASSWORD` value,
+whose single source of truth is `compose/.env.example` (Compose) and
+`k8s/postgresql/authentik-postgresql.yml` (KinD). Read it with
+`grep AUTHENTIK_BOOTSTRAP_PASSWORD compose/.env.example`.
 
 ## Environment configuration (`.env.example`)
 

--- a/README.md
+++ b/README.md
@@ -209,8 +209,10 @@ Run `make help` for the full list. Common targets:
 
 ## Web UI
 
-Log in to the Authentik admin interface with `akadmin` / `Authentik01234567890!`
-(Compose: `https://localhost:9443/if/admin/`). See [docs/web-ui.md](docs/web-ui.md)
+Log in as `akadmin` (Authentik's default bootstrap admin); the password is the
+`AUTHENTIK_BOOTSTRAP_PASSWORD` value in [`compose/.env.example`](compose/.env.example)
+(`grep AUTHENTIK_BOOTSTRAP_PASSWORD compose/.env.example`) — the single source of
+truth (Compose: `https://localhost:9443/if/admin/`). See [docs/web-ui.md](docs/web-ui.md)
 for annotated screenshots of the provisioned users, groups, and tokens, plus how
 to regenerate them.
 

--- a/docs/spikes/authentik-cockroachdb-yugabytedb.md
+++ b/docs/spikes/authentik-cockroachdb-yugabytedb.md
@@ -217,6 +217,31 @@ version-specific regression a point release fixes. YugabyteDB remains **experime
 the next revisit should target a YugabyteDB release that materially changes DDL-transaction retry
 semantics (or an Authentik that tolerates non-PostgreSQL transaction models), not merely a newer patch.
 
+### 6c. Deep spike — exhausting every documented mitigation on 2025.2.4.0 (2026-06-27)
+
+Before closing the YugabyteDB door, every documented mitigation was tried against the
+**latest** image (`:latest` = `2025.2.4.0-b122`, confirmed — no newer stable or preview
+line exists). Two parallel primary-source research passes mapped the root cause; the
+verdicts were gated on **DB state** (migration count + `authentik_core_group` existence),
+not log banners (an earlier harness false-passed on the pre-migration `Booting authentik`
+line — see `common/testing.md`).
+
+| Mitigation tried | Result | Why |
+|------------------|--------|-----|
+| `ysql_output_buffer_size=128MB` + `yb_max_query_layer_retries=120` | ❌ FAIL at ~16 migrations (`YB001`) | **Red herring.** The buffer governs *single-statement* read-restart retries; the failure is a *multi-statement* DDL+DML atomic txn aborted by conflict, where retry is impossible because an earlier statement already returned rows ([yugabyte#22949](https://github.com/yugabyte/yugabyte-db/issues/22949)). |
+| `ysql_yb_ddl_transaction_block_enabled=true` (preview) alone | ❌ FAIL at ~2 migrations | New error surfaces earlier: `FeatureNotSupported: interleaving SAVEPOINT & DDL in transaction disallowed without DDL savepoint support` — Django's migration executor uses savepoints, which the preview transactional-DDL mode forbids. |
+| **BOTH** preview flags: `ysql_yb_ddl_transaction_block_enabled=true` + `ysql_yb_enable_ddl_savepoint_support=true` | ⚠️ Furthest ever — reaches **47 migrations** and creates `authentik_core_group` (past the wall that killed every prior run), then **HANGS** at ~migration 48 (`authentik_providers_saml`) for >11 min with no progress and no error | An effective deadlock in the stacked preview transactional-DDL + DDL-savepoint path. |
+
+**Conclusion:** even the latest YugabyteDB plus *every* documented mitigation — including
+stacking **two tech-preview** gflags — does not produce a working Authentik install; the
+best case advances further but deadlocks mid-migration. A backend that requires stacking
+tech-preview features (explicitly not production-ready, with documented concurrent-DDL
+conflict + weaker-isolation caveats) and still hangs is **not viable**. The official
+`django-yugabytedb` backend is also moot here — its latest release targets Django 3.2/4.0,
+while Authentik 2026.5 runs Django 5.x. The verdict stands: **PostgreSQL remains the only
+supported datastore**; revisit only when YugabyteDB GAs transactional DDL *with* savepoint
+support and Postgres-equivalent DDL isolation — not on a patch/minor bump.
+
 ## 7. Recommendation for this repo
 
 | Action | Recommendation |

--- a/docs/web-ui.md
+++ b/docs/web-ui.md
@@ -3,7 +3,14 @@
 Screenshots of the Authentik admin interface after the provisioner has created
 the demo `org-01` / `org-02` groups, users, and API tokens.
 
-Log in to the Authentik admin interface with `akadmin` / `Authentik01234567890!`.
+Log in as `akadmin` (Authentik's default bootstrap admin). The password is the
+`AUTHENTIK_BOOTSTRAP_PASSWORD` value in [`../compose/.env.example`](../compose/.env.example)
+— the single source of truth (for the KinD deployment it's the same key in
+`../k8s/postgresql/authentik-postgresql.yml`). Read it with:
+
+```bash
+grep AUTHENTIK_BOOTSTRAP_PASSWORD compose/.env.example
+```
 
 - **Docker Compose:** `https://localhost:9443/if/admin/`
 - **Kubernetes:** `https://<LB-IP>:443/if/admin/` (get the IP via `kubectl get svc authentik-server -o jsonpath='{.status.loadBalancer.ingress[0].ip}'`)


### PR DESCRIPTION
Two doc changes:

**1. Admin credential → single source of truth.** README, CLAUDE.md, and docs/web-ui.md stopped restating the admin password literal (`Authentik01234567890!`). They now reference its source of truth — `AUTHENTIK_BOOTSTRAP_PASSWORD` in `compose/.env.example` (KinD: the same key in `k8s/postgresql/authentik-postgresql.yml`) — and show how to read it (`grep`). The literal now lives only in its config homes (`.env.example`, `main.go` fallback, k8s manifests). Prevents drift + stops scattering the value into prose where gitleaks misses it. gitleaks verified clean.

**2. YugabyteDB deep-spike result (docs/spikes §6c).** Recorded the exhaustive re-test: latest `2025.2.4.0` + every documented mitigation (output-buffer = red herring; `ysql_yb_ddl_transaction_block_enabled` + `ysql_yb_enable_ddl_savepoint_support` preview flags) still fails — best case reaches 47 migrations (creates `authentik_core_group`) then **deadlocks** at ~migration 48. Requiring stacked tech-preview flags + still hanging ⇒ not viable. PostgreSQL stays the only supported datastore. No upstream tickets (findings are known/by-design).

🤖 Generated with [Claude Code](https://claude.com/claude-code)