### PR TITLE
docs: make admin-login instructions unambiguous (username vs password value)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,11 +59,12 @@ helm repo add authentik https://charts.goauthentik.io && helm repo update
 helm template authentik authentik/authentik -f ./k8s/postgresql/values.yml > ./k8s/postgresql/authentik-postgresql.yml
 ```
 
-Default admin login: `akadmin` (Authentik's fixed bootstrap admin user). The
-password is **not** restated here — it is the `AUTHENTIK_BOOTSTRAP_PASSWORD` value,
-whose single source of truth is `compose/.env.example` (Compose) and
-`k8s/postgresql/authentik-postgresql.yml` (KinD). Read it with
-`grep AUTHENTIK_BOOTSTRAP_PASSWORD compose/.env.example`.
+Default admin login — **username** `akadmin` (Authentik's fixed bootstrap user;
+hardcoded, no env var, so stated literally). The **password** is the *value* of
+`AUTHENTIK_BOOTSTRAP_PASSWORD` (not restated here; single source of truth:
+`compose/.env.example` for Compose, `k8s/postgresql/authentik-postgresql.yml` for
+KinD) — extract just the value with
+`grep AUTHENTIK_BOOTSTRAP_PASSWORD compose/.env.example | cut -d= -f2`.
 
 ## Environment configuration (`.env.example`)
 

--- a/README.md
+++ b/README.md
@@ -209,10 +209,11 @@ Run `make help` for the full list. Common targets:
 
 ## Web UI
 
-Log in as `akadmin` (Authentik's default bootstrap admin); the password is the
-`AUTHENTIK_BOOTSTRAP_PASSWORD` value in [`compose/.env.example`](compose/.env.example)
-(`grep AUTHENTIK_BOOTSTRAP_PASSWORD compose/.env.example`) — the single source of
-truth (Compose: `https://localhost:9443/if/admin/`). See [docs/web-ui.md](docs/web-ui.md)
+At the login screen enter username `akadmin` (Authentik's fixed bootstrap admin,
+hardcoded — no env var); at the password screen enter the **value** of
+`AUTHENTIK_BOOTSTRAP_PASSWORD` from [`compose/.env.example`](compose/.env.example),
+its single source of truth — `grep AUTHENTIK_BOOTSTRAP_PASSWORD compose/.env.example | cut -d= -f2`.
+(Compose admin UI: `https://localhost:9443/if/admin/`.) See [docs/web-ui.md](docs/web-ui.md)
 for annotated screenshots of the provisioned users, groups, and tokens, plus how
 to regenerate them.
 

--- a/docs/web-ui.md
+++ b/docs/web-ui.md
@@ -3,14 +3,20 @@
 Screenshots of the Authentik admin interface after the provisioner has created
 the demo `org-01` / `org-02` groups, users, and API tokens.
 
-Log in as `akadmin` (Authentik's default bootstrap admin). The password is the
-`AUTHENTIK_BOOTSTRAP_PASSWORD` value in [`../compose/.env.example`](../compose/.env.example)
-— the single source of truth (for the KinD deployment it's the same key in
-`../k8s/postgresql/authentik-postgresql.yml`). Read it with:
+The Authentik login flow has two screens — an **Identification** screen (username
+or email), then a **Password** screen. Enter:
 
-```bash
-grep AUTHENTIK_BOOTSTRAP_PASSWORD compose/.env.example
-```
+- **Username** (Identification screen): `akadmin` — Authentik's bootstrap admin.
+  This username is hardcoded by Authentik (there is no env var for it), so it is
+  stated literally here.
+- **Password** (Password screen): the **value** of `AUTHENTIK_BOOTSTRAP_PASSWORD`
+  in [`../compose/.env.example`](../compose/.env.example) — the single source of
+  truth (KinD: the same key in `../k8s/postgresql/authentik-postgresql.yml`). Print
+  just the value (the part after `=`) and type that into the Password field:
+
+  ```bash
+  grep AUTHENTIK_BOOTSTRAP_PASSWORD compose/.env.example | cut -d= -f2
+  ```
 
 - **Docker Compose:** `https://localhost:9443/if/admin/`
 - **Kubernetes:** `https://<LB-IP>:443/if/admin/` (get the IP via `kubectl get svc authentik-server -o jsonpath='{.status.loadBalancer.ingress[0].ip}'`)


### PR DESCRIPTION
Follow-up to #31. The credential-source references were technically correct but practically unclear:

- A bare `grep AUTHENTIK_BOOTSTRAP_PASSWORD compose/.env.example` prints `AUTHENTIK_BOOTSTRAP_PASSWORD=Authentik01234567890!` — the `KEY=` prefix is **not** the password, and nothing said these were a username+password to type into the two login screens.

Fixes across README, CLAUDE.md, docs/web-ui.md:
- **Username** `akadmin` is now stated as Authentik's *hardcoded* bootstrap user (no env var) — clarifying why it is stated literally rather than "grabbed from source of truth" (there's nothing to grab).
- **Password** instruction now extracts just the value (`| cut -d= -f2`) and names the field it goes into (the Password screen).

Skill rule updated to match (`/readme`: credential-source references must be *usable* — value-only extraction + name the field + flag fixed defaults).

🤖 Generated with [Claude Code](https://claude.com/claude-code)