### PR TITLE
feat: generate k8s manifest from Authentik Helm chart (postgres-only, drop Valkey)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,7 @@ jobs:
     timeout-minutes: 2
     outputs:
       code: ${{ steps.filter.outputs.code }}
+      k8s: ${{ steps.filter.outputs.k8s }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4
@@ -42,6 +43,10 @@ jobs:
               - 'CLAUDE.md'
               - 'compose/**'
               - '.dclintrc.yaml'
+            k8s:
+              - 'k8s/postgresql/**'
+              - 'provisioner/Makefile'
+              - 'provisioner/.mise.toml'
 
   static-check:
     needs: [changes]
@@ -118,6 +123,27 @@ jobs:
       - name: Build + scan image
         run: make image-scan
 
+  # Drift gate: the committed k8s/postgresql manifest is generated from the pinned
+  # Authentik Helm chart + values.yml. Fail if it's stale (e.g. a Renovate chart
+  # bump without a regen). helm-only (template + diff) — no cluster needed.
+  k8s-drift:
+    needs: [changes]
+    if: ${{ !failure() && !cancelled() && needs.changes.outputs.k8s == 'true' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    defaults:
+      run:
+        working-directory: provisioner
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      - uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d # v4.2.0
+        with:
+          install: true
+          cache: true
+          working_directory: provisioner
+      - name: Verify k8s manifest matches the pinned chart + values.yml
+        run: make k8s-generate-check
+
   # Live e2e: stand up Authentik via Docker Compose, provision + verify with the
   # Go POC, tear down. No secrets needed (demo bootstrap token from .env.example).
   e2e:
@@ -140,7 +166,7 @@ jobs:
 
   ci-pass:
     if: always()
-    needs: [changes, static-check, build, test, docker, e2e]
+    needs: [changes, static-check, build, test, docker, k8s-drift, e2e]
     runs-on: ubuntu-latest
     timeout-minutes: 2
     steps:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,7 +20,7 @@ The Go POC and the deployment are decoupled: you stand up Authentik first (compo
   - `internal/util/utils.go` — TLS transport (skips verify), pointer helpers (`*bool`, `*int32`, `*string` — the client takes pointers for optional fields).
   - `Dockerfile` — multi-stage, static binary on distroless-nonroot; a one-shot job (no port/healthcheck), config supplied via env at runtime (`make image-build` / `image-run`).
   - `.env.example` — committed source of truth for the POC's env vars; copy to `.env` (gitignored). `e2e_test.go` is the build-tagged (`//go:build e2e`) live test driven by `make e2e-compose` / `make e2e`.
-- `k8s/postgresql/` — Authentik manifests (PostgreSQL backend), pre-generated via `helm template`, plus the `values.yml` used to generate them.
+- `k8s/postgresql/` — Authentik manifests (PostgreSQL backend). **Generated** by `make k8s-generate` from the pinned Authentik Helm chart (`AUTHENTIK_CHART_VERSION` in the Makefile) + `values.yml` (Bitnami subcharts disabled), concatenated with `oss-datastores.yml` (the OSS `postgres:18-alpine` workload), with Helm metadata labels stripped. A CI `k8s-drift` job (`make k8s-generate-check`) fails if the committed manifest is stale. No Redis/Valkey — Authentik 2026.5 is PostgreSQL-only.
 - `k8s/kind-config.yaml` — single-node KinD cluster config used by `make e2e`.
 - `compose/` — Docker Compose stack (Authentik server + worker + PostgreSQL; **no Redis** — Authentik dropped the Redis dependency in 2025.10, everything is PostgreSQL-backed now). `compose/.env.example` is the committed source of truth; `compose/.env` is gitignored. Linted by `make compose-lint` (dclint; rule config in `.dclintrc.yaml`).
 - `docs/` — `web-ui.md` (admin-UI screenshots + how to regenerate them) and `spikes/` (the CockroachDB/YugabyteDB datastore investigation — manifests since removed as non-working; PostgreSQL is the only backend). Screenshots live in `docs/img/`.
@@ -52,9 +52,9 @@ make compose-up / compose-down  # bring the Compose Authentik stack up / tear it
 
 make renovate-validate          # validate renovate.json
 
-# --- Regenerate the k8s manifests from the Helm chart ---
-helm repo add authentik https://charts.goauthentik.io && helm repo update
-helm template authentik authentik/authentik -f ./k8s/postgresql/values.yml > ./k8s/postgresql/authentik-postgresql.yml
+# --- Regenerate the k8s manifest from the pinned Authentik Helm chart ---
+make -C provisioner k8s-generate        # helm template (subcharts off) + oss-datastores.yml + strip Helm labels
+make -C provisioner k8s-generate-check  # drift gate: fail if the committed manifest is stale vs chart+values
 ```
 
 Default admin login — **username** `akadmin` (Authentik's fixed bootstrap user;
@@ -98,7 +98,7 @@ cp compose/.env.example  compose/.env    # Compose stack: PG_*, AUTHENTIK_SECRET
 
 - **POC flow** (`CreateGroupsAndUsers`, called 4× for org-01/org-02 × admin/user): create group → create user in group → set password → create API token → retrieve the Authentik-generated key → overwrite it with a known key → re-create an API client *as that user* with the known token → call `MeRetrieveUser` to read the user's groups. The final step demonstrates a non-privileged token can read its own group membership.
 
-- **Manifests are committed artifacts generated from `values.yml`** — but with **two intentional hand-edits**: (1) the `AUTHENTIK_BOOTSTRAP_PASSWORD`/`AUTHENTIK_BOOTSTRAP_TOKEN` env on server+worker; (2) the PostgreSQL and Redis workloads were swapped from the chart's **Bitnami subchart images (removed from Docker Hub in 2025)** to **OSS Deployments** — `postgres:18-alpine` and `valkey/valkey:9-alpine` (Valkey = the BSD/Linux-Foundation Redis fork). The postgres Deployment sets `PGDATA=/var/lib/postgresql/data/pgdata` (an explicit subdir), which keeps the postgres:18+ image — whose default data dir relocated to `/var/lib/postgresql` — working with the existing `/var/lib/postgresql/data` mount (the compose stack, which has no explicit `PGDATA`, instead mounts the volume at `/var/lib/postgresql`). They keep the original Service selectors/ports and read DB creds from the `authentik` Secret, so `authentik-server` connects unchanged. **Regenerating from the chart reintroduces Bitnami** — re-apply the OSS swap after any `helm template` (or disable the chart's bundled `postgresql`/`redis` and point Authentik at the OSS workloads). A few now-unused Bitnami `ConfigMap`s (redis-scripts/health/config, pg-extended-config) remain as harmless dead config.
+- **The k8s manifest is GENERATED, not hand-edited** — `make k8s-generate` (don't edit `k8s/postgresql/authentik-postgresql.yml` by hand; the `k8s-drift` CI gate will fail). It renders the pinned Authentik Helm chart with the bundled **Bitnami `postgresql` subchart disabled** (the Bitnami image was removed from Docker Hub) + `values.yml` (external DB host, `secret_key`, the `AUTHENTIK_BOOTSTRAP_PASSWORD`/`TOKEN` env on server+worker), strips the Helm metadata labels, and concatenates `oss-datastores.yml` — the OSS `postgres:18-alpine` Deployment+Service. The postgres Deployment reads creds from the chart-generated `authentik` Secret (`AUTHENTIK_POSTGRESQL__*`), so it stays in sync with `values.yml`, and sets `PGDATA=/var/lib/postgresql/data/pgdata` (explicit subdir) so the postgres:18 image — whose default data dir moved to `/var/lib/postgresql` — works with the `/var/lib/postgresql/data` mount (the compose stack, no explicit `PGDATA`, mounts the volume at `/var/lib/postgresql`). **No Redis/Valkey** — Authentik dropped Redis in 2025.10 (cache, task broker, and WebSocket channels are all PostgreSQL-backed). To change the deployment, edit `values.yml` / `oss-datastores.yml` and re-run `make k8s-generate`.
 
 - **Namespace is `default` end-to-end.** Every resource in `k8s/postgresql/authentik-postgresql.yml` is pinned to `namespace: "default"`, and the `provisioner/` Makefile deploy path (`kind-deploy`) uses `AUTHENTIK_NS := default` — they match. (A former standalone `deploy-authentik-k8s.sh` that patched/waited against `-n threeport-api` was removed; the Makefile is the only deploy path now.)
 
@@ -128,7 +128,7 @@ When spawning subagents to work on any of the above, always pass the relevant sk
 
 ## Upgrade Backlog
 
-Deferred / monitor items from `/upgrade-analysis` (2026-06-26). The repo is otherwise fully current — Go 1.26.4, all mise tools at latest, Authentik 2026.5, postgres 18 / valkey 9, kubectl 1.36.2 / kind 0.32 / node v1.36.1 (aligned), cloud-provider-kind 0.11.1, all Action SHAs at current major tags; `govulncheck` clean; Renovate alive (automerge on, no Errored branches).
+Deferred / monitor items from `/upgrade-analysis` (2026-06-26). The repo is otherwise fully current — Go 1.26.4, all mise tools at latest, Authentik 2026.5, postgres 18, kubectl 1.36.2 / kind 0.32 / node v1.36.1 (aligned), cloud-provider-kind 0.11.1, all Action SHAs at current major tags; `govulncheck` clean; Renovate alive (automerge on, no Errored branches).
 
 - [ ] **Alternative datastores (CockroachDB / YugabyteDB) — closed, not deferred.** Both were evaluated and removed as non-working (CockroachDB lacks session `pg_advisory_lock()` — [cockroachdb#169981](https://github.com/cockroachdb/cockroach/issues/169981), open; YugabyteDB aborts Authentik's migrations on `YB001` even with every documented mitigation). Full investigation retained in `docs/spikes/authentik-cockroachdb-yugabytedb.md`. PostgreSQL is the only supported backend; no revisit planned unless that analysis's "revisit when…" conditions are met.
 - [ ] **Renovate `lock-file-maintenance`** is in "Awaiting Schedule" (working as designed — periodic `go.sum` refresh); no action needed.

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ A proof-of-concept that drives [Authentik](https://goauthentik.io/) programmatic
 
 The repo has two halves:
 
-- **Deploy Authentik** — locally via Docker Compose (lightweight) or on a full Kubernetes cluster via KinD (with `cloud-provider-kind` for LoadBalancer support and OSS PostgreSQL + Valkey datastores).
+- **Deploy Authentik** — locally via Docker Compose (lightweight) or on a full Kubernetes cluster via KinD (with `cloud-provider-kind` for LoadBalancer support and OSS PostgreSQL datastore).
 - **`provisioner/`** — a Go program that provisions a demo org structure (groups, users, tokens) and verifies it end-to-end via the Authentik client.
 
 ```mermaid
@@ -25,19 +25,16 @@ flowchart LR
         direction TB
         SERVER["Authentik server<br/>REST API + Web UI"]
         WORKER["Authentik worker<br/>background tasks"]
-        PG[("PostgreSQL")]
-        REDIS[("Redis / Valkey")]
+        PG[("PostgreSQL<br/>(cache + broker + channels too)")]
         SERVER --- WORKER
         SERVER --> PG
-        SERVER --> REDIS
         WORKER --> PG
-        WORKER --> REDIS
     end
 
     POC -->|"HTTPS REST API + admin bootstrap token"| SERVER
 
     COMPOSE["Option A: Docker Compose (compose/)<br/>target https://127.0.0.1:9443"]
-    KIND["Option B: KinD + cloud-provider-kind (k8s/)<br/>LoadBalancer IP, target https://LB-IP:443<br/>postgres:18-alpine, valkey:9-alpine"]
+    KIND["Option B: KinD + cloud-provider-kind (k8s/)<br/>LoadBalancer IP, target https://LB-IP:443<br/>postgres:18-alpine"]
 
     COMPOSE -.deploys.-> AUTHENTIK
     KIND -.deploys.-> AUTHENTIK
@@ -48,7 +45,7 @@ flowchart LR
     classDef deploy fill:#f3e5f5,stroke:#6a1b9a,color:#4a148c;
     class POC poc;
     class SERVER,WORKER svc;
-    class PG,REDIS data;
+    class PG data;
     class COMPOSE,KIND deploy;
 ```
 
@@ -110,7 +107,7 @@ Authentik is served at `https://127.0.0.1:9443`.
 
 ### Kubernetes (KinD)
 
-Stands up a full KinD cluster with a `cloud-provider-kind` LoadBalancer and OSS PostgreSQL + Valkey datastores:
+Stands up a full KinD cluster with a `cloud-provider-kind` LoadBalancer and OSS PostgreSQL datastore:
 
 ```bash
 cd provisioner
@@ -199,6 +196,7 @@ Run `make help` for the full list. Common targets:
 | `make image-scan` | Build the image and scan it for HIGH/CRITICAL CVEs (Trivy) |
 | `make compose-up` / `make compose-down` | Start / stop the Authentik Compose stack |
 | `make kind-up` / `make kind-down` | Create+deploy / destroy the KinD cluster |
+| `make k8s-generate` | Regenerate `k8s/postgresql/` from the pinned Authentik chart + `values.yml` |
 | `make e2e-compose` / `make e2e` | End-to-end against Compose / KinD |
 | `make renovate-validate` | Validate `renovate.json` |
 | `make ci` | Full local CI pipeline (`static-check` + `test` + `build`) |
@@ -220,7 +218,7 @@ to regenerate them.
 ## Notes & caveats
 
 - **Demo credentials.** All shipped secrets in `.env.example` files are for demonstration only — rotate them before any real use.
-- **OSS datastores.** The Kubernetes PostgreSQL/Redis were swapped from the removed Bitnami images to OSS `postgres` + `valkey`.
+- **OSS datastore.** The Kubernetes manifest is generated from the Authentik Helm chart with its bundled Bitnami PostgreSQL subchart disabled (the Bitnami image was removed from Docker Hub) and an OSS `postgres:18-alpine` workload supplied instead — see `make k8s-generate`. No Redis/Valkey: Authentik dropped Redis in 2025.10 (cache, task broker, and channels are all PostgreSQL-backed).
 - **PostgreSQL is the only supported datastore.** CockroachDB and YugabyteDB were evaluated as alternatives and neither works with Authentik's Django migrations (CockroachDB lacks session `pg_advisory_lock()`; YugabyteDB has it but its distributed-transaction model aborts the migrations on `YB001`). The experimental manifests were removed; the full investigation is kept in [`docs/spikes/authentik-cockroachdb-yugabytedb.md`](docs/spikes/authentik-cockroachdb-yugabytedb.md).
 
 ## References

--- a/k8s/postgresql/authentik-postgresql.yml
+++ b/k8s/postgresql/authentik-postgresql.yml
@@ -1,15 +1,4 @@
 ---
-# Source: authentik/charts/redis/templates/serviceaccount.yaml
-apiVersion: v1
-kind: ServiceAccount
-automountServiceAccountToken: true
-metadata:
-  name: authentik-redis
-  namespace: "default"
-  labels:
-    app.kubernetes.io/instance: authentik
-    app.kubernetes.io/name: redis
----
 # Source: authentik/charts/serviceAccount/templates/serviceaccount.yaml
 apiVersion: v1
 kind: ServiceAccount
@@ -20,21 +9,7 @@ metadata:
     app.kubernetes.io/name: "serviceAccount"
     app.kubernetes.io/instance: "authentik"
     app.kubernetes.io/part-of: "authentik"
----
-# Source: authentik/charts/postgresql/templates/secrets.yaml
-apiVersion: v1
-kind: Secret
-metadata:
-  name: authentik-postgresql
-  namespace: "default"
-  labels:
-    app.kubernetes.io/instance: authentik
-    app.kubernetes.io/name: postgresql
-type: Opaque
-data:
-  postgres-password: "cWQ4MGE2QnhqRA=="
-  password: "bXUyVktzWllSdQ=="
-  # We don't auto-generate LDAP password when it's not provided as we do for other passwords
+
 ---
 # Source: authentik/templates/secret.yaml
 apiVersion: v1
@@ -51,6 +26,7 @@ data:
   AUTHENTIK_EMAIL__TIMEOUT: "MzA="
   AUTHENTIK_EMAIL__USE_SSL: "ZmFsc2U="
   AUTHENTIK_EMAIL__USE_TLS: "ZmFsc2U="
+  AUTHENTIK_ENABLED: "dHJ1ZQ=="
   AUTHENTIK_ERROR_REPORTING__ENABLED: "ZmFsc2U="
   AUTHENTIK_ERROR_REPORTING__ENVIRONMENT: "azhz"
   AUTHENTIK_ERROR_REPORTING__SEND_PII: "ZmFsc2U="
@@ -63,183 +39,9 @@ data:
   AUTHENTIK_POSTGRESQL__PASSWORD: "VGhpc0lzTm90QVNlY3VyZVBhc3N3b3Jk"
   AUTHENTIK_POSTGRESQL__PORT: "NTQzMg=="
   AUTHENTIK_POSTGRESQL__USER: "YXV0aGVudGlr"
-  AUTHENTIK_REDIS__HOST: "YXV0aGVudGlrLXJlZGlzLW1hc3Rlcg=="
   AUTHENTIK_SECRET_KEY: "UGxlYXNlR2VuZXJhdGVBNTBDaGFyS2V5"
----
-# Source: authentik/charts/postgresql/templates/primary/extended-configmap.yaml
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: authentik-postgresql-extended-configuration
-  namespace: "default"
-  labels:
-    app.kubernetes.io/instance: authentik
-    app.kubernetes.io/name: postgresql
-    app.kubernetes.io/component: primary
-data:
-  override.conf: |-
-    max_connections = 500
----
-# Source: authentik/charts/redis/templates/configmap.yaml
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: authentik-redis-configuration
-  namespace: "default"
-  labels:
-    app.kubernetes.io/instance: authentik
-    app.kubernetes.io/name: redis
-data:
-  redis.conf: |-
-    # User-supplied common configuration:
-    # Enable AOF https://redis.io/topics/persistence#append-only-file
-    appendonly yes
-    # Disable RDB persistence, AOF persistence already enabled.
-    save ""
-    # End of common configuration
-  master.conf: |-
-    dir /data
-    # User-supplied master configuration:
-    rename-command FLUSHDB ""
-    rename-command FLUSHALL ""
-    # End of master configuration
-  replica.conf: |-
-    dir /data
-    # User-supplied replica configuration:
-    rename-command FLUSHDB ""
-    rename-command FLUSHALL ""
-    # End of replica configuration
----
-# Source: authentik/charts/redis/templates/health-configmap.yaml
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: authentik-redis-health
-  namespace: "default"
-  labels:
-    app.kubernetes.io/instance: authentik
-    app.kubernetes.io/name: redis
-data:
-  ping_readiness_local.sh: |-
-    #!/bin/bash
+  AUTHENTIK_WEB__PATH: "Lw=="
 
-    [[ -f $REDIS_PASSWORD_FILE ]] && export REDIS_PASSWORD="$(< "${REDIS_PASSWORD_FILE}")"
-    [[ -n "$REDIS_PASSWORD" ]] && export REDISCLI_AUTH="$REDIS_PASSWORD"
-    response=$(
-      timeout -s 15 $1 \
-      redis-cli \
-        -h localhost \
-        -p $REDIS_PORT \
-        ping
-    )
-    if [ "$?" -eq "124" ]; then
-      echo "Timed out"
-      exit 1
-    fi
-    if [ "$response" != "PONG" ]; then
-      echo "$response"
-      exit 1
-    fi
-  ping_liveness_local.sh: |-
-    #!/bin/bash
-
-    [[ -f $REDIS_PASSWORD_FILE ]] && export REDIS_PASSWORD="$(< "${REDIS_PASSWORD_FILE}")"
-    [[ -n "$REDIS_PASSWORD" ]] && export REDISCLI_AUTH="$REDIS_PASSWORD"
-    response=$(
-      timeout -s 15 $1 \
-      redis-cli \
-        -h localhost \
-        -p $REDIS_PORT \
-        ping
-    )
-    if [ "$?" -eq "124" ]; then
-      echo "Timed out"
-      exit 1
-    fi
-    responseFirstWord=$(echo $response | head -n1 | awk '{print $1;}')
-    if [ "$response" != "PONG" ] && [ "$responseFirstWord" != "LOADING" ] && [ "$responseFirstWord" != "MASTERDOWN" ]; then
-      echo "$response"
-      exit 1
-    fi
-  ping_readiness_master.sh: |-
-    #!/bin/bash
-
-    [[ -f $REDIS_MASTER_PASSWORD_FILE ]] && export REDIS_MASTER_PASSWORD="$(< "${REDIS_MASTER_PASSWORD_FILE}")"
-    [[ -n "$REDIS_MASTER_PASSWORD" ]] && export REDISCLI_AUTH="$REDIS_MASTER_PASSWORD"
-    response=$(
-      timeout -s 15 $1 \
-      redis-cli \
-        -h $REDIS_MASTER_HOST \
-        -p $REDIS_MASTER_PORT_NUMBER \
-        ping
-    )
-    if [ "$?" -eq "124" ]; then
-      echo "Timed out"
-      exit 1
-    fi
-    if [ "$response" != "PONG" ]; then
-      echo "$response"
-      exit 1
-    fi
-  ping_liveness_master.sh: |-
-    #!/bin/bash
-
-    [[ -f $REDIS_MASTER_PASSWORD_FILE ]] && export REDIS_MASTER_PASSWORD="$(< "${REDIS_MASTER_PASSWORD_FILE}")"
-    [[ -n "$REDIS_MASTER_PASSWORD" ]] && export REDISCLI_AUTH="$REDIS_MASTER_PASSWORD"
-    response=$(
-      timeout -s 15 $1 \
-      redis-cli \
-        -h $REDIS_MASTER_HOST \
-        -p $REDIS_MASTER_PORT_NUMBER \
-        ping
-    )
-    if [ "$?" -eq "124" ]; then
-      echo "Timed out"
-      exit 1
-    fi
-    responseFirstWord=$(echo $response | head -n1 | awk '{print $1;}')
-    if [ "$response" != "PONG" ] && [ "$responseFirstWord" != "LOADING" ]; then
-      echo "$response"
-      exit 1
-    fi
-  ping_readiness_local_and_master.sh: |-
-    script_dir="$(dirname "$0")"
-    exit_status=0
-    "$script_dir/ping_readiness_local.sh" $1 || exit_status=$?
-    "$script_dir/ping_readiness_master.sh" $1 || exit_status=$?
-    exit $exit_status
-  ping_liveness_local_and_master.sh: |-
-    script_dir="$(dirname "$0")"
-    exit_status=0
-    "$script_dir/ping_liveness_local.sh" $1 || exit_status=$?
-    "$script_dir/ping_liveness_master.sh" $1 || exit_status=$?
-    exit $exit_status
----
-# Source: authentik/charts/redis/templates/scripts-configmap.yaml
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: authentik-redis-scripts
-  namespace: "default"
-  labels:
-    app.kubernetes.io/instance: authentik
-    app.kubernetes.io/name: redis
-data:
-  start-master.sh: |
-    #!/bin/bash
-
-    [[ -f $REDIS_PASSWORD_FILE ]] && export REDIS_PASSWORD="$(< "${REDIS_PASSWORD_FILE}")"
-    if [[ -f /opt/bitnami/redis/mounted-etc/master.conf ]];then
-        cp /opt/bitnami/redis/mounted-etc/master.conf /opt/bitnami/redis/etc/master.conf
-    fi
-    if [[ -f /opt/bitnami/redis/mounted-etc/redis.conf ]];then
-        cp /opt/bitnami/redis/mounted-etc/redis.conf /opt/bitnami/redis/etc/redis.conf
-    fi
-    ARGS=("--port" "${REDIS_PORT}")
-    ARGS+=("--protected-mode" "no")
-    ARGS+=("--include" "/opt/bitnami/redis/etc/redis.conf")
-    ARGS+=("--include" "/opt/bitnami/redis/etc/master.conf")
-    exec redis-server "${ARGS[@]}"
 ---
 # Source: authentik/charts/serviceAccount/templates/clusterrole.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -257,6 +59,7 @@ rules:
       - customresourcedefinitions
     verbs:
       - list
+
 ---
 # Source: authentik/charts/serviceAccount/templates/clusterrolebinding.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -275,6 +78,7 @@ subjects:
   - kind: ServiceAccount
     name: authentik
     namespace: "default"
+
 ---
 # Source: authentik/charts/serviceAccount/templates/role.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -333,6 +137,16 @@ rules:
       - list
       - patch
   - apiGroups:
+      - gateway.networking.k8s.io
+    resources:
+      - httproutes
+    verbs:
+      - get
+      - create
+      - delete
+      - list
+      - patch
+  - apiGroups:
       - monitoring.coreos.com
     resources:
       - servicemonitors
@@ -348,6 +162,7 @@ rules:
       - customresourcedefinitions
     verbs:
       - list
+
 ---
 # Source: authentik/charts/serviceAccount/templates/rolebinding.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -367,107 +182,7 @@ subjects:
   - kind: ServiceAccount
     name: authentik
     namespace: "default"
----
-# Source: authentik/charts/postgresql/templates/primary/svc-headless.yaml
-apiVersion: v1
-kind: Service
-metadata:
-  name: authentik-postgresql-hl
-  namespace: "default"
-  labels:
-    app.kubernetes.io/instance: authentik
-    app.kubernetes.io/name: postgresql
-    app.kubernetes.io/component: primary
-  annotations:
-    # Use this annotation in addition to the actual publishNotReadyAddresses
-    # field below because the annotation will stop being respected soon but the
-    # field is broken in some versions of Kubernetes:
-    # https://github.com/kubernetes/kubernetes/issues/58662
-    service.alpha.kubernetes.io/tolerate-unready-endpoints: "true"
-spec:
-  type: ClusterIP
-  clusterIP: None
-  # We want all pods in the StatefulSet to have their addresses published for
-  # the sake of the other Postgresql pods even before they're ready, since they
-  # have to be able to talk to each other in order to become ready.
-  publishNotReadyAddresses: true
-  ports:
-    - name: tcp-postgresql
-      port: 5432
-      targetPort: tcp-postgresql
-  selector:
-    app.kubernetes.io/instance: authentik
-    app.kubernetes.io/name: postgresql
-    app.kubernetes.io/component: primary
----
-# Source: authentik/charts/postgresql/templates/primary/svc.yaml
-apiVersion: v1
-kind: Service
-metadata:
-  name: authentik-postgresql
-  namespace: "default"
-  labels:
-    app.kubernetes.io/instance: authentik
-    app.kubernetes.io/name: postgresql
-    app.kubernetes.io/component: primary
-spec:
-  type: ClusterIP
-  sessionAffinity: None
-  ports:
-    - name: tcp-postgresql
-      port: 5432
-      targetPort: tcp-postgresql
-      nodePort: null
-  selector:
-    app.kubernetes.io/instance: authentik
-    app.kubernetes.io/name: postgresql
-    app.kubernetes.io/component: primary
----
-# Source: authentik/charts/redis/templates/headless-svc.yaml
-apiVersion: v1
-kind: Service
-metadata:
-  name: authentik-redis-headless
-  namespace: "default"
-  labels:
-    app.kubernetes.io/instance: authentik
-    app.kubernetes.io/name: redis
-  annotations:
-    
-spec:
-  type: ClusterIP
-  clusterIP: None
-  ports:
-    - name: tcp-redis
-      port: 6379
-      targetPort: redis
-  selector:
-    app.kubernetes.io/instance: authentik
-    app.kubernetes.io/name: redis
----
-# Source: authentik/charts/redis/templates/master/service.yaml
-apiVersion: v1
-kind: Service
-metadata:
-  name: authentik-redis-master
-  namespace: "default"
-  labels:
-    app.kubernetes.io/instance: authentik
-    app.kubernetes.io/name: redis
-    app.kubernetes.io/component: master
-spec:
-  type: ClusterIP
-  internalTrafficPolicy: Cluster
-  sessionAffinity: None
-  ports:
-    - name: tcp-redis
-      port: 6379
-      targetPort: redis
-      nodePort: null
-  selector:
-    app.kubernetes.io/instance: authentik
-    app.kubernetes.io/name: redis
-    app.kubernetes.io/component: master
+
 ---
 # Source: authentik/templates/server/service.yaml
 apiVersion: v1
@@ -495,6 +210,7 @@ spec:
     app.kubernetes.io/name: "authentik"
     app.kubernetes.io/instance: "authentik"
     app.kubernetes.io/component: "server"
+
 ---
 # Source: authentik/templates/server/deployment.yaml
 apiVersion: apps/v1
@@ -523,26 +239,20 @@ spec:
         app.kubernetes.io/component: "server"
         app.kubernetes.io/part-of: "authentik"
       annotations:
-        checksum/secret: a2082ed4488b583f0e460f2f74a314a5e2c1e9ae17bef60ddd71214494f5eea9
+        checksum/secret: 9d5d293a6ea4da77ef3fc302b44e753e3483dc88e01e17245be1462da42830be
     spec:
       terminationGracePeriodSeconds: 30
       containers:
         - name: server
-          image: ghcr.io/goauthentik/server:2026.5
+          image: ghcr.io/goauthentik/server:2026.5.3
           imagePullPolicy: IfNotPresent
           args:
             - server
           env:
-            - name: AUTHENTIK_LISTEN__HTTP
-              value: "0.0.0.0:9000"
-            - name: AUTHENTIK_LISTEN__HTTPS
-              value: "0.0.0.0:9443"
-            - name: AUTHENTIK_LISTEN__METRICS
-              value: "0.0.0.0:9300"
             - name: AUTHENTIK_BOOTSTRAP_PASSWORD
-              value: "Authentik01234567890!"
+              value: Authentik01234567890!
             - name: AUTHENTIK_BOOTSTRAP_TOKEN
-              value: "NoMlxBQuYgfu3j19ygGqhjXenAjrJgOfN5naqmSDBUhdLjYqHKze7yyzY07H"  
+              value: NoMlxBQuYgfu3j19ygGqhjXenAjrJgOfN5naqmSDBUhdLjYqHKze7yyzY07H
           envFrom:
             - secretRef:
                 name: authentik
@@ -560,32 +270,32 @@ spec:
             
             failureThreshold: 3
             httpGet:
-              path: /-/health/live/
+              path: '/-/health/live/'
               port: http
             initialDelaySeconds: 5
             periodSeconds: 10
             successThreshold: 1
-            timeoutSeconds: 1
+            timeoutSeconds: 3
           readinessProbe:
             
             failureThreshold: 3
             httpGet:
-              path: /-/health/ready/
+              path: '/-/health/ready/'
               port: http
             initialDelaySeconds: 5
             periodSeconds: 10
             successThreshold: 1
-            timeoutSeconds: 1
+            timeoutSeconds: 3
           startupProbe:
             
             failureThreshold: 60
             httpGet:
-              path: /-/health/live/
+              path: '/-/health/live/'
               port: http
             initialDelaySeconds: 5
             periodSeconds: 10
             successThreshold: 1
-            timeoutSeconds: 1
+            timeoutSeconds: 3
           resources:
             {}
       affinity:
@@ -600,6 +310,7 @@ spec:
                     app.kubernetes.io/component: "server"
                 topologyKey: kubernetes.io/hostname
       enableServiceLinks: true
+
 ---
 # Source: authentik/templates/worker/deployment.yaml
 apiVersion: apps/v1
@@ -628,24 +339,31 @@ spec:
         app.kubernetes.io/component: "worker"
         app.kubernetes.io/part-of: "authentik"
       annotations:
-        checksum/secret: a2082ed4488b583f0e460f2f74a314a5e2c1e9ae17bef60ddd71214494f5eea9
+        checksum/secret: 9d5d293a6ea4da77ef3fc302b44e753e3483dc88e01e17245be1462da42830be
     spec:
       serviceAccountName: authentik
       terminationGracePeriodSeconds: 30
       containers:
         - name: worker
-          image: ghcr.io/goauthentik/server:2026.5
+          image: ghcr.io/goauthentik/server:2026.5.3
           imagePullPolicy: IfNotPresent
           args:
             - worker
           env:
             - name: AUTHENTIK_BOOTSTRAP_PASSWORD
-              value: "Authentik01234567890!"
+              value: Authentik01234567890!
             - name: AUTHENTIK_BOOTSTRAP_TOKEN
-              value: "NoMlxBQuYgfu3j19ygGqhjXenAjrJgOfN5naqmSDBUhdLjYqHKze7yyzY07H"  
+              value: NoMlxBQuYgfu3j19ygGqhjXenAjrJgOfN5naqmSDBUhdLjYqHKze7yyzY07H
           envFrom:
             - secretRef:
                 name: authentik
+          ports:
+            - name: http
+              containerPort: 9000
+              protocol: TCP
+            - name: metrics
+              containerPort: 9300
+              protocol: TCP
           livenessProbe:
             
             exec:
@@ -656,7 +374,7 @@ spec:
             initialDelaySeconds: 5
             periodSeconds: 10
             successThreshold: 1
-            timeoutSeconds: 1
+            timeoutSeconds: 3
           readinessProbe:
             
             exec:
@@ -667,7 +385,7 @@ spec:
             initialDelaySeconds: 5
             periodSeconds: 10
             successThreshold: 1
-            timeoutSeconds: 1
+            timeoutSeconds: 3
           startupProbe:
             
             exec:
@@ -678,7 +396,7 @@ spec:
             initialDelaySeconds: 30
             periodSeconds: 10
             successThreshold: 1
-            timeoutSeconds: 1
+            timeoutSeconds: 3
           resources:
             {}
       affinity:
@@ -693,17 +411,42 @@ spec:
                     app.kubernetes.io/component: "worker"
                 topologyKey: kubernetes.io/hostname
       enableServiceLinks: true
+# OSS PostgreSQL datastore for the Authentik Helm chart (subcharts disabled).
+# Concatenated into k8s/postgresql/authentik-postgresql.yml by `make k8s-generate`.
+# The chart's bundled Bitnami postgresql was removed from Docker Hub; this is the
+# OSS postgres:18-alpine replacement. It reads POSTGRES_USER/PASSWORD/DB from the
+# chart-generated `authentik` Secret (AUTHENTIK_POSTGRESQL__*), so it stays in
+# sync with values.yml. PGDATA is an explicit subdir so postgres:18 (which moved
+# its default data dir to /var/lib/postgresql) works with the data mount.
+# NOTE: no Redis/Valkey — Authentik dropped Redis in 2025.10 (all PostgreSQL-backed).
 ---
-# OSS PostgreSQL — replaces the removed Bitnami image (bitnami/postgresql tags
-# were purged from Docker Hub in 2025). Minimal single-replica Deployment for
-# the e2e/demo stack; pod labels match the existing authentik-postgresql
-# Service selector so authentik-server routes here unchanged. Connection params
-# (user/db/password) are read from the same `authentik` Secret the server uses.
+apiVersion: v1
+kind: Service
+metadata:
+  name: authentik-postgresql
+  namespace: default
+  labels:
+    app.kubernetes.io/instance: authentik
+    app.kubernetes.io/name: postgresql
+    app.kubernetes.io/component: primary
+spec:
+  type: ClusterIP
+  sessionAffinity: None
+  ports:
+  - name: tcp-postgresql
+    port: 5432
+    targetPort: tcp-postgresql
+    nodePort: null
+  selector:
+    app.kubernetes.io/instance: authentik
+    app.kubernetes.io/name: postgresql
+    app.kubernetes.io/component: primary
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: authentik-postgresql
-  namespace: "default"
+  namespace: default
   labels:
     app.kubernetes.io/instance: authentik
     app.kubernetes.io/name: postgresql
@@ -723,82 +466,41 @@ spec:
         app.kubernetes.io/component: primary
     spec:
       containers:
-        - name: postgresql
-          # postgres:18+ relocated its default data dir, but the explicit
-          # PGDATA=/var/lib/postgresql/data/pgdata below keeps the 18 image
-          # happy with the existing mount (no volume-path change needed here,
-          # unlike the compose stack which has no explicit PGDATA).
-          image: postgres:18-alpine@sha256:1b1689b20d16a014a3d195653381cf2caa75a41a92d93b255a9d6ea29fd353aa
-          imagePullPolicy: IfNotPresent
-          env:
-            - name: POSTGRES_USER
-              valueFrom:
-                secretKeyRef:
-                  name: authentik
-                  key: AUTHENTIK_POSTGRESQL__USER
-            - name: POSTGRES_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: authentik
-                  key: AUTHENTIK_POSTGRESQL__PASSWORD
-            - name: POSTGRES_DB
-              valueFrom:
-                secretKeyRef:
-                  name: authentik
-                  key: AUTHENTIK_POSTGRESQL__NAME
-            - name: PGDATA
-              value: /var/lib/postgresql/data/pgdata
-          ports:
-            - name: tcp-postgresql
-              containerPort: 5432
-          readinessProbe:
-            exec:
-              command: ["sh", "-c", "pg_isready -U \"$POSTGRES_USER\" -d \"$POSTGRES_DB\""]
-            initialDelaySeconds: 5
-            periodSeconds: 5
-          volumeMounts:
-            - name: data
-              mountPath: /var/lib/postgresql/data
-      volumes:
+      - name: postgresql
+        image: postgres:18-alpine@sha256:1b1689b20d16a014a3d195653381cf2caa75a41a92d93b255a9d6ea29fd353aa
+        imagePullPolicy: IfNotPresent
+        env:
+        - name: POSTGRES_USER
+          valueFrom:
+            secretKeyRef:
+              name: authentik
+              key: AUTHENTIK_POSTGRESQL__USER
+        - name: POSTGRES_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: authentik
+              key: AUTHENTIK_POSTGRESQL__PASSWORD
+        - name: POSTGRES_DB
+          valueFrom:
+            secretKeyRef:
+              name: authentik
+              key: AUTHENTIK_POSTGRESQL__NAME
+        - name: PGDATA
+          value: /var/lib/postgresql/data/pgdata
+        ports:
+        - name: tcp-postgresql
+          containerPort: 5432
+        readinessProbe:
+          exec:
+            command:
+            - sh
+            - -c
+            - pg_isready -U "$POSTGRES_USER" -d "$POSTGRES_DB"
+          initialDelaySeconds: 5
+          periodSeconds: 5
+        volumeMounts:
         - name: data
-          emptyDir: {}
----
-# OSS Valkey — BSD-licensed, Linux-Foundation Redis fork; replaces the removed
-# Bitnami image (bitnami/redis). Wire-compatible with the redis client Authentik
-# uses. Pod labels match the existing authentik-redis-master Service selector.
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: authentik-redis-master
-  namespace: "default"
-  labels:
-    app.kubernetes.io/instance: authentik
-    app.kubernetes.io/name: redis
-    app.kubernetes.io/component: master
-spec:
-  replicas: 1
-  selector:
-    matchLabels:
-      app.kubernetes.io/instance: authentik
-      app.kubernetes.io/name: redis
-      app.kubernetes.io/component: master
-  template:
-    metadata:
-      labels:
-        app.kubernetes.io/instance: authentik
-        app.kubernetes.io/name: redis
-        app.kubernetes.io/component: master
-    spec:
-      containers:
-        - name: redis
-          image: valkey/valkey:9-alpine@sha256:a35428eba9043cc0b79dbe54100f0c92784f2de00ad09b01182bfb1c5c83d1bd
-          imagePullPolicy: IfNotPresent
-          args: ["--save", "60", "1", "--loglevel", "warning"]
-          ports:
-            - name: redis
-              containerPort: 6379
-          readinessProbe:
-            exec:
-              command: ["sh", "-c", "valkey-cli ping | grep -q PONG"]
-            initialDelaySeconds: 5
-            periodSeconds: 5
+          mountPath: /var/lib/postgresql/data
+      volumes:
+      - name: data
+        emptyDir: {}

--- a/k8s/postgresql/oss-datastores.yml
+++ b/k8s/postgresql/oss-datastores.yml
@@ -1,0 +1,93 @@
+# OSS PostgreSQL datastore for the Authentik Helm chart (subcharts disabled).
+# Concatenated into k8s/postgresql/authentik-postgresql.yml by `make k8s-generate`.
+# The chart's bundled Bitnami postgresql was removed from Docker Hub; this is the
+# OSS postgres:18-alpine replacement. It reads POSTGRES_USER/PASSWORD/DB from the
+# chart-generated `authentik` Secret (AUTHENTIK_POSTGRESQL__*), so it stays in
+# sync with values.yml. PGDATA is an explicit subdir so postgres:18 (which moved
+# its default data dir to /var/lib/postgresql) works with the data mount.
+# NOTE: no Redis/Valkey — Authentik dropped Redis in 2025.10 (all PostgreSQL-backed).
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: authentik-postgresql
+  namespace: default
+  labels:
+    app.kubernetes.io/instance: authentik
+    app.kubernetes.io/name: postgresql
+    app.kubernetes.io/component: primary
+spec:
+  type: ClusterIP
+  sessionAffinity: None
+  ports:
+  - name: tcp-postgresql
+    port: 5432
+    targetPort: tcp-postgresql
+    nodePort: null
+  selector:
+    app.kubernetes.io/instance: authentik
+    app.kubernetes.io/name: postgresql
+    app.kubernetes.io/component: primary
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: authentik-postgresql
+  namespace: default
+  labels:
+    app.kubernetes.io/instance: authentik
+    app.kubernetes.io/name: postgresql
+    app.kubernetes.io/component: primary
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: authentik
+      app.kubernetes.io/name: postgresql
+      app.kubernetes.io/component: primary
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/instance: authentik
+        app.kubernetes.io/name: postgresql
+        app.kubernetes.io/component: primary
+    spec:
+      containers:
+      - name: postgresql
+        image: postgres:18-alpine@sha256:1b1689b20d16a014a3d195653381cf2caa75a41a92d93b255a9d6ea29fd353aa
+        imagePullPolicy: IfNotPresent
+        env:
+        - name: POSTGRES_USER
+          valueFrom:
+            secretKeyRef:
+              name: authentik
+              key: AUTHENTIK_POSTGRESQL__USER
+        - name: POSTGRES_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: authentik
+              key: AUTHENTIK_POSTGRESQL__PASSWORD
+        - name: POSTGRES_DB
+          valueFrom:
+            secretKeyRef:
+              name: authentik
+              key: AUTHENTIK_POSTGRESQL__NAME
+        - name: PGDATA
+          value: /var/lib/postgresql/data/pgdata
+        ports:
+        - name: tcp-postgresql
+          containerPort: 5432
+        readinessProbe:
+          exec:
+            command:
+            - sh
+            - -c
+            - pg_isready -U "$POSTGRES_USER" -d "$POSTGRES_DB"
+          initialDelaySeconds: 5
+          periodSeconds: 5
+        volumeMounts:
+        - name: data
+          mountPath: /var/lib/postgresql/data
+      volumes:
+      - name: data
+        emptyDir: {}

--- a/k8s/postgresql/values.yml
+++ b/k8s/postgresql/values.yml
@@ -1,23 +1,43 @@
+# Single source of truth for the Authentik Helm chart inputs. The committed
+# k8s/postgresql/authentik-postgresql.yml is GENERATED from this by
+# `make -C provisioner k8s-generate` (chart pinned via AUTHENTIK_CHART_VERSION in
+# the provisioner Makefile) + concatenated k8s/postgresql/oss-datastores.yml, with
+# Helm metadata labels stripped. A CI drift gate (k8s-drift job) fails if the
+# committed manifest is out of sync with this file + the pinned chart.
+#
+# Demo credentials — rotate for any real deployment.
 authentik:
-    secret_key: "PleaseGenerateA50CharKey"
-    # This sends anonymous usage-data, stack traces on errors and
-    # performance data to sentry.io, and is fully opt-in
-    error_reporting:
-        enabled: false
-    postgresql:
-        password: "ThisIsNotASecurePassword"
+  secret_key: "PleaseGenerateA50CharKey"
+  # Anonymous usage data / error reporting to sentry.io — opt-in, disabled here.
+  error_reporting:
+    enabled: false
+  # External PostgreSQL (the chart's bundled Bitnami subchart is disabled below).
+  # host matches the OSS postgres Service name in oss-datastores.yml.
+  postgresql:
+    host: "authentik-postgresql"
+    name: "authentik"
+    user: "authentik"
+    password: "ThisIsNotASecurePassword"
+    port: 5432
 
-
-# ingress:
-#     enabled: true
-#     hosts:
-#         - host: authentik.domain.tld
-#           paths:
-#               - path: "/"
-#                 pathType: Prefix
-
+# Disable the chart's bundled Bitnami PostgreSQL subchart — its image was removed
+# from Docker Hub. We run OSS postgres:18-alpine from oss-datastores.yml instead.
+# (Authentik 2026.5 needs NO Redis — task broker, cache, and channels are all
+# PostgreSQL-backed since 2025.10 — so there is no redis subchart to disable.)
 postgresql:
-    enabled: true
-    postgresqlPassword: "ThisIsNotASecurePassword"
-redis:
-    enabled: true
+  enabled: false
+
+# Bootstrap the akadmin password + API token. Authentik reads these from env on
+# first start; set on BOTH server and worker (either can run the bootstrap).
+server:
+  env:
+    - name: AUTHENTIK_BOOTSTRAP_PASSWORD
+      value: "Authentik01234567890!"
+    - name: AUTHENTIK_BOOTSTRAP_TOKEN
+      value: "NoMlxBQuYgfu3j19ygGqhjXenAjrJgOfN5naqmSDBUhdLjYqHKze7yyzY07H"
+worker:
+  env:
+    - name: AUTHENTIK_BOOTSTRAP_PASSWORD
+      value: "Authentik01234567890!"
+    - name: AUTHENTIK_BOOTSTRAP_TOKEN
+      value: "NoMlxBQuYgfu3j19ygGqhjXenAjrJgOfN5naqmSDBUhdLjYqHKze7yyzY07H"

--- a/provisioner/Makefile
+++ b/provisioner/Makefile
@@ -16,8 +16,15 @@ COMPOSE     := docker compose --project-directory $(COMPOSE_DIR) -f $(COMPOSE_DI
 KIND_CLUSTER_NAME ?= authentik-e2e
 KUBECTL           := kubectl --context=kind-$(KIND_CLUSTER_NAME)
 MANIFEST          := ../k8s/postgresql/authentik-postgresql.yml
+K8S_DIR           := ../k8s/postgresql
 KIND_CONFIG       := ../k8s/kind-config.yaml
 AUTHENTIK_NS      := default
+HELM_REPO_URL     := https://charts.goauthentik.io
+# Authentik Helm chart version — the SOURCE for `make k8s-generate`. The committed
+# k8s manifest is regenerated from this chart + k8s/postgresql/values.yml; a CI
+# drift gate (k8s-drift) fails if they're out of sync. Chart version == app version.
+# renovate: datasource=helm depName=authentik registryUrl=https://charts.goauthentik.io
+AUTHENTIK_CHART_VERSION := 2026.5.3
 # Track the REGISTRY image (the consumed sink), not the GitHub release: registry.k8s.io
 # image promotion lags the upstream release, so github-releases proposes un-pullable tags.
 # The `# renovate:` line MUST stay immediately above the constant (customManager adjacency).
@@ -231,12 +238,32 @@ kind-create: deps-kind
 		-v /var/run/docker.sock:/var/run/docker.sock \
 		registry.k8s.io/cloud-provider-kind/cloud-controller-manager:v$(CLOUD_PROVIDER_KIND_VERSION) >/dev/null
 
+#k8s-generate: @ Regenerate the k8s manifest from the pinned Authentik chart + OSS datastores
+k8s-generate: deps
+	@helm repo add authentik $(HELM_REPO_URL) >/dev/null 2>&1 || true; helm repo update authentik >/dev/null 2>&1
+	@{ helm template authentik authentik/authentik --version $(AUTHENTIK_CHART_VERSION) -f $(K8S_DIR)/values.yml --namespace $(AUTHENTIK_NS) \
+	   | sed -E '/^[[:space:]]*helm\.sh\/chart:/d; /^[[:space:]]*app\.kubernetes\.io\/version:/d; /^[[:space:]]*app\.kubernetes\.io\/managed-by:[[:space:]]*"?Helm"?[[:space:]]*$$/d'; \
+	   cat $(K8S_DIR)/oss-datastores.yml; } > $(MANIFEST)
+	@echo "k8s-generate: wrote $(MANIFEST)"
+
+#k8s-generate-check: @ Drift gate — fail if the committed k8s manifest is out of sync with the chart + values.yml
+k8s-generate-check: deps
+	@helm repo add authentik $(HELM_REPO_URL) >/dev/null 2>&1 || true; helm repo update authentik >/dev/null 2>&1
+	@{ helm template authentik authentik/authentik --version $(AUTHENTIK_CHART_VERSION) -f $(K8S_DIR)/values.yml --namespace $(AUTHENTIK_NS) \
+	   | sed -E '/^[[:space:]]*helm\.sh\/chart:/d; /^[[:space:]]*app\.kubernetes\.io\/version:/d; /^[[:space:]]*app\.kubernetes\.io\/managed-by:[[:space:]]*"?Helm"?[[:space:]]*$$/d'; \
+	   cat $(K8S_DIR)/oss-datastores.yml; } > /tmp/k8s-gen-check.yml
+	@if diff -u $(MANIFEST) /tmp/k8s-gen-check.yml >/dev/null 2>&1; then \
+	   echo "k8s-generate-check: in sync"; \
+	 else \
+	   echo "DRIFT: $(MANIFEST) is stale vs the pinned chart + values.yml — run 'make k8s-generate' and commit:"; \
+	   diff -u $(MANIFEST) /tmp/k8s-gen-check.yml | head -50; exit 1; \
+	 fi
+
 #kind-deploy: @ Deploy Authentik to the KinD cluster and wait until ready
 kind-deploy: kind-create
-	@$(KUBECTL) apply --server-side --force-conflicts -f $(MANIFEST)
-	@echo "Waiting for PostgreSQL + Redis (OSS: postgres + valkey)..."
+	@$(KUBECTL) -n $(AUTHENTIK_NS) apply --server-side --force-conflicts -f $(MANIFEST)
+	@echo "Waiting for PostgreSQL (OSS postgres:18)..."
 	@$(KUBECTL) -n $(AUTHENTIK_NS) rollout status deployment/authentik-postgresql --timeout=180s
-	@$(KUBECTL) -n $(AUTHENTIK_NS) rollout status deployment/authentik-redis-master --timeout=180s
 	@echo "Waiting for Authentik server + worker..."
 	@$(KUBECTL) -n $(AUTHENTIK_NS) rollout status deployment/authentik-server --timeout=300s
 	@$(KUBECTL) -n $(AUTHENTIK_NS) rollout status deployment/authentik-worker --timeout=300s
@@ -282,6 +309,6 @@ ci: static-check test build
 	@echo "Local CI pipeline passed."
 
 .PHONY: help deps deps-check check-toolchain-alignment build run test lint lint-docker \
-	vulncheck mermaid-lint compose-lint trivy-fs secrets static-check image-build image-run image-scan update clean renovate-validate \
+	vulncheck mermaid-lint compose-lint trivy-fs secrets static-check image-build image-run image-scan k8s-generate k8s-generate-check update clean renovate-validate \
 	compose-up compose-down compose-logs e2e-compose deps-kind kind-create kind-deploy \
 	e2e kind-destroy kind-up kind-down ci

--- a/renovate.json
+++ b/renovate.json
@@ -31,7 +31,7 @@
       "description": "Makefile tool-version constants pinned via # renovate: comments. currentValue must start with a digit so image refs are handled by the dedicated manager below.",
       "managerFilePatterns": ["/(^|/)Makefile$/"],
       "matchStrings": [
-        "# renovate: datasource=(?<datasource>\\S+) depName=(?<depName>\\S+)(?: versioning=(?<versioning>\\S+))?(?: extractVersion=(?<extractVersion>\\S+))?\\s+[A-Z0-9_]+\\s*:?=\\s*(?<currentValue>[0-9][^\\s@]*)"
+        "# renovate: datasource=(?<datasource>\\S+) depName=(?<depName>\\S+)(?: registryUrl=(?<registryUrl>\\S+))?(?: versioning=(?<versioning>\\S+))?(?: extractVersion=(?<extractVersion>\\S+))?\\s+[A-Z0-9_]+\\s*:?=\\s*(?<currentValue>[0-9][^\\s@]*)"
       ]
     },
     {


### PR DESCRIPTION
Completes the Redis removal (after #34 did Compose) **and** delivers the requested k8s-manifest regeneration pipeline.

## What
- **`make k8s-generate`** regenerates `k8s/postgresql/authentik-postgresql.yml` from the **pinned** Authentik Helm chart (`AUTHENTIK_CHART_VERSION=2026.5.3`) + `values.yml` (Bitnami `postgresql` subchart disabled, external DB) → strips Helm metadata labels → concatenates `oss-datastores.yml` (OSS `postgres:18-alpine`). **`make k8s-generate-check`** is the drift gate.
- **Drop Valkey/Redis from k8s** — Authentik removed Redis in 2025.10 (PostgreSQL-backed cache/broker/channels). The regenerated manifest has **0 Redis/Valkey, 0 Bitnami residue, 0 stale Helm labels** (11 resources).
- **`values.yml`** is now the single source of truth (subcharts off, external DB host, `secret_key`, bootstrap env); **`oss-datastores.yml`** is the OSS postgres workload (reads creds from the chart-generated `authentik` Secret; `PGDATA` subdir for pg18).
- **CI `k8s-drift` job** (helm-only, no cluster) gated on a new `k8s` paths-filter; wired into `ci-pass`. A Renovate chart bump that isn't regenerated now fails CI.
- **Renovate**: customManager gained a `registryUrl` group → the `authentik` helm chart version is tracked (`datasource=helm`).
- README architecture diagram + docs: Authentik is PostgreSQL-only.

## Verified
- `make k8s-generate-check`: **in sync**.
- `make static-check`: **rc=0** (mermaid diagram parses, gitleaks clean on new k8s files).
- **`make e2e` (KinD): PASSES** — the regenerated postgres-only manifest deploys and the provisioner runs end-to-end against it (`e2e OK ... https://172.18.0.5:443`). KinD isn't in CI, so this was verified locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)