### PR TITLE
docs: clarify diagram label — 'deploy via Docker Compose OR KinD'

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ The repo has two halves:
 flowchart LR
     POC["POC binary (provisioner/)<br/>Go client goauthentik.io/api/v3"]
 
-    subgraph AUTHENTIK["Authentik stack — run EITHER way"]
+    subgraph AUTHENTIK["Authentik stack — deploy via Docker Compose OR KinD"]
         direction TB
         SERVER["Authentik server<br/>REST API + Web UI"]
         WORKER["Authentik worker<br/>background tasks"]


### PR DESCRIPTION
The architecture-diagram subgraph said "Authentik stack — run EITHER way", which is vague about *which* two ways. Renamed to "Authentik stack — deploy via Docker Compose OR KinD" so it names the two deploy options directly (they're the Option A / Option B nodes below it).

mermaid-lint verified locally (README-only change skips the CI static-check, so the diagram was validated locally).

🤖 Generated with [Claude Code](https://claude.com/claude-code)