### PR TITLE
docs: org/group/user hierarchy diagram + *.md review fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,34 @@ For each demo org — `org-01` and `org-02` — and for both an admin and a regu
 3. overwrites the token with a known key,
 4. re-authenticates **as that user** with the token and reads back its group membership.
 
+The resulting structure (org → group → user + API token):
+
+```mermaid
+flowchart TD
+    subgraph ORG1["org-01 — path orgs/org-01"]
+        G1A["group: org-01-admins<br/>(superuser)"]
+        G1U["group: org-01-users"]
+        U1A["user: org-01-admin<br/>token: org-01-admin-token"]
+        U1U["user: org-01-user<br/>token: org-01-user-token"]
+        G1A --> U1A
+        G1U --> U1U
+    end
+    subgraph ORG2["org-02 — path orgs/org-02"]
+        G2A["group: org-02-admins<br/>(superuser)"]
+        G2U["group: org-02-users"]
+        U2A["user: org-02-admin<br/>token: org-02-admin-token"]
+        U2U["user: org-02-user<br/>token: org-02-user-token"]
+        G2A --> U2A
+        G2U --> U2U
+    end
+    classDef grp fill:#e8f5e9,stroke:#2e7d32,color:#1b5e20;
+    classDef usr fill:#e3f2fd,stroke:#1565c0,color:#0d47a1;
+    class G1A,G1U,G2A,G2U grp;
+    class U1A,U1U,U2A,U2U usr;
+```
+
+The flow the POC runs against the API for each pair:
+
 ```mermaid
 sequenceDiagram
     autonumber

--- a/docs/spikes/authentik-traefik-dns-records.md
+++ b/docs/spikes/authentik-traefik-dns-records.md
@@ -193,7 +193,7 @@ func BindAppToEmbeddedOutpost(ctx context.Context, apiClient *api.APIClient, pro
 **Config additions** (`provisioner/.env.example` — the committed source of truth, per the repo's
 parameter-externalization rule; no hardcoded hosts/domains):
 
-```
+```bash
 AUTHENTIK_FORWARD_AUTH_ENABLED=false          # opt-in; default off so existing POC behavior is unchanged
 AUTHENTIK_COOKIE_DOMAIN=domain.tld
 AUTHENTIK_FORWARD_AUTH_EXTERNAL_HOST=https://authentik.domain.tld


### PR DESCRIPTION
- **New mermaid hierarchy diagram** in README "Running the POC" — org → group → user + API token, showing the four group/user pairs the provisioner creates (e.g. `org-01-admins` → `org-01-admin` + `org-01-admin-token`). mermaid-lint verified locally.
- **`*.md` inconsistency review** (README, CLAUDE, docs/web-ui, both spikes): the one finding fixed is an unfenced env-var block in the Traefik spike (added `bash`). Otherwise clean — exactly 1 H1/file, consistent versions (2026.5.3 / postgres 18 / Go 1.26.4 / Redis-removed-2025.10), no broken anchors, placeholders, or trailing whitespace. The lone 'Redis' mention left in the Traefik spike faithfully describes an **external** reference repo's stack, not this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)