### PR TITLE
chore: Makefile help (drop Redis) + scope Renovate kubernetes manager to OSS-datastore source

### DIFF
--- a/provisioner/Makefile
+++ b/provisioner/Makefile
@@ -181,7 +181,7 @@ renovate-validate:
 # Authentik via Docker Compose (lightweight local alternative to KinD)
 # ---------------------------------------------------------------------------
 
-#compose-up: @ Start Authentik (PostgreSQL+Redis+server+worker) via Compose and wait until ready
+#compose-up: @ Start Authentik (PostgreSQL+server+worker) via Compose and wait until ready
 compose-up:
 	@[ -f $(COMPOSE_DIR)/.env ] || cp $(COMPOSE_DIR)/.env.example $(COMPOSE_DIR)/.env
 	@$(COMPOSE) up -d

--- a/renovate.json
+++ b/renovate.json
@@ -23,7 +23,7 @@
   "automerge": false,
   "postUpdateOptions": ["gomodTidy"],
   "kubernetes": {
-    "managerFilePatterns": ["/k8s/.+\\.ya?ml$/"]
+    "managerFilePatterns": ["/k8s/postgresql/oss-datastores\\.yml$/"]
   },
   "customManagers": [
     {
@@ -120,10 +120,10 @@
       "enabled": false
     },
     {
-      "description": "Group the Authentik server image across the k8s manifest (kubernetes manager) and compose .env (custom.regex). Both pin the rolling `2026.5` tag; pinDigests:false keeps them symmetric (the env tag cannot carry a digest) so dedup doesn't drop one side.",
-      "matchManagers": ["kubernetes", "custom.regex"],
-      "matchPackageNames": ["ghcr.io/goauthentik/server"],
-      "groupName": "Authentik server",
+      "description": "Group the Authentik upgrade into one PR: the compose .env image tag (ghcr.io/goauthentik/server, docker) and the Helm chart pin that drives the k8s manifest (authentik, helm via AUTHENTIK_CHART_VERSION) — both custom.regex. A chart bump regenerates the k8s manifest (the k8s-drift gate enforces `make k8s-generate`); pinDigests:false because the env tag cannot carry a digest. (The k8s manifest's image is NOT tracked directly — it's generated from the chart pin; see the kubernetes manager scope above.)",
+      "matchManagers": ["custom.regex"],
+      "matchPackageNames": ["ghcr.io/goauthentik/server", "authentik"],
+      "groupName": "Authentik",
       "pinDigests": false
     }
   ]


### PR DESCRIPTION
Two fixes found while verifying 'all Makefile targets run' + the `/renovate` review:

- **Makefile** `compose-up` help still said `(PostgreSQL+Redis+server+worker)` — a Redis leftover from the Redis-drop (caught via `make help`). Now `(PostgreSQL+server+worker)`. All targets verified: `make ci` rc=0, `k8s-generate-check` in-sync, `image-scan` rc=0, `renovate-validate` clean.
- **renovate.json** — the `kubernetes` manager was scanning the **generated** `authentik-postgresql.yml`, so Renovate tracked its authentik image (chart appVersion `2026.5.3`): a value `make k8s-generate` overwrites AND one that collided with compose's rolling `2026.5` tag. Scoped the manager to the hand-maintained `oss-datastores.yml` (postgres source) only; the authentik image is driven by the chart pin (`AUTHENTIK_CHART_VERSION`, helm). Regrouped compose tag + chart pin into one **"Authentik"** PR. Verified via `renovate --platform=local`: kubernetes scans 1 file, authentik image no longer double-tracked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)