### PR TITLE
docs: ordered org tree (org-01 first) + traefik-spike currency refresh

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,30 +126,27 @@ For each demo org — `org-01` and `org-02` — and for both an admin and a regu
 3. overwrites the token with a known key,
 4. re-authenticates **as that user** with the token and reads back its group membership.
 
-The resulting structure (org → group → user + API token):
+The resulting structure — a tree of org → group → user (+ API token), built per org `org-01` then `org-02`:
 
 ```mermaid
 flowchart TD
-    subgraph ORG1["org-01 — path orgs/org-01"]
-        G1A["group: org-01-admins<br/>(superuser)"]
-        G1U["group: org-01-users"]
-        U1A["user: org-01-admin<br/>token: org-01-admin-token"]
-        U1U["user: org-01-user<br/>token: org-01-user-token"]
-        G1A --> U1A
-        G1U --> U1U
-    end
-    subgraph ORG2["org-02 — path orgs/org-02"]
-        G2A["group: org-02-admins<br/>(superuser)"]
-        G2U["group: org-02-users"]
-        U2A["user: org-02-admin<br/>token: org-02-admin-token"]
-        U2U["user: org-02-user<br/>token: org-02-user-token"]
-        G2A --> U2A
-        G2U --> U2U
-    end
+    ROOT(["Authentik<br/>provisioned via the Go client"])
+    ROOT --> O1["org-01<br/>path: orgs/org-01"]
+    ROOT --> O2["org-02<br/>path: orgs/org-02"]
+    O1 --> O1A["group: org-01-admins<br/>(superuser)"]
+    O1 --> O1U["group: org-01-users"]
+    O1A --> O1AU["user: org-01-admin<br/>token: org-01-admin-token"]
+    O1U --> O1UU["user: org-01-user<br/>token: org-01-user-token"]
+    O2 --> O2A["group: org-02-admins<br/>(superuser)"]
+    O2 --> O2U["group: org-02-users"]
+    O2A --> O2AU["user: org-02-admin<br/>token: org-02-admin-token"]
+    O2U --> O2UU["user: org-02-user<br/>token: org-02-user-token"]
+    classDef org fill:#fff3e0,stroke:#ef6c00,color:#e65100;
     classDef grp fill:#e8f5e9,stroke:#2e7d32,color:#1b5e20;
     classDef usr fill:#e3f2fd,stroke:#1565c0,color:#0d47a1;
-    class G1A,G1U,G2A,G2U grp;
-    class U1A,U1U,U2A,U2U usr;
+    class O1,O2 org;
+    class O1A,O1U,O2A,O2U grp;
+    class O1AU,O1UU,O2AU,O2UU usr;
 ```
 
 The flow the POC runs against the API for each pair:

--- a/docs/spikes/authentik-traefik-dns-records.md
+++ b/docs/spikes/authentik-traefik-dns-records.md
@@ -180,7 +180,8 @@ func BindAppToEmbeddedOutpost(ctx context.Context, apiClient *api.APIClient, pro
 
 **Orchestration** in `provisioner/main.go` (after the existing groups/users flow), domain-wide variant:
 
-1. `FlowsInstancesList(...)` filtered by slug → resolve `default-authentication-flow` /
+1. `FlowsInstancesList(...)` filtered by slug → resolve `default-provider-authorization-implicit-consent`
+   (the provider's **authorization** flow — NOT `default-authentication-flow`) /
    `default-provider-invalidation-flow` PKs (do **not** hardcode PKs — they differ per instance).
 2. `CreateForwardAuthProvider(ctx, c, "Domain Forward Auth Provider", api.PROXYMODE_FORWARD_DOMAIN, "https://"+host, cookieDomain, authzFlow, invFlow)`.
 3. `CreateApplication(ctx, c, "Domain Forward Auth Application", "domain-forward-auth-application", provider.Pk, "")`.
@@ -224,7 +225,7 @@ configures **Authentik's** side of the contract, Traefik config configures **Tra
 
 | Topic | Note |
 |-------|------|
-| **Version discipline** | Confirm `forwardAuth` + embedded-outpost behavior on **Authentik 2026.5** (this repo) vs the guide's 2024-era assumptions, and on **current Traefik** (the guide pins `traefik:3.0.4`, June 2024 — newer 3.x exists). Read the **2026.5** outpost docs before wiring; do not transcribe flow slugs/PKs from the guide — resolve them at runtime via `FlowsInstancesList`. |
+| **Version discipline** | Confirmed against **Authentik 2026.5** + **Traefik v3.7.5** (current as of 2026-06; the guide pins `traefik:3.0.4`, June 2024 — ~7 minors behind + carries CVEs). The forward-auth contract holds on both (verified 2026-06-27). Notes: (1) Traefik `trustForwardHeader` is **deprecated since v3.6.14** — use the entryPoint `forwardedHeaders.trustedIPs` form (the guide already does). (2) The guide's `my-compose` ships **Redis**, which is **obsolete on Authentik 2026.5** — Authentik removed Redis in 2025.10 (cache/broker/channels are PostgreSQL-backed); drop it if mirroring that compose. Do not transcribe flow slugs/PKs from the guide — resolve them at runtime via `FlowsInstancesList`. |
 | **Flow slugs are not stable contracts** | Default flow slugs can change across Authentik releases. The provisioner must **look them up**, not pin them; treat the `.env` slug values as overridable hints with a list-and-resolve fallback. |
 | **DNS Records are Cloudflare- and public-domain-specific** | The guide's ACME `dnsChallenge` requires a real internet-resolvable zone + Cloudflare API token. **KinD/compose labs have no public DNS** → Idea #4 cannot be a default; needs a user decision on whether a real domain is in scope. Alternatives: `nip.io`-style wildcard DNS, `/etc/hosts`/`hostAliases`, or a different lego DNS provider. |
 | **k8s outpost endpoint** | On k8s the forwardAuth address must target the Authentik **Service** DNS (e.g. `http://authentik-server.default.svc:9000/outpost.goauthentik.io/auth/traefik`), not the compose name `authentik_server`. Reconcile with the existing `namespace: default` vs `threeport-api` mismatch noted in `CLAUDE.md`. |
@@ -241,8 +242,8 @@ configures **Authentik's** side of the contract, Traefik config configures **Tra
 - Traefik compose service (Cloudflare token secret): <https://github.com/brokenscripts/authentik_traefik/blob/traefik3/my-compose/traefik/compose.yaml>
 - whoami demo compose: <https://github.com/brokenscripts/authentik_traefik/blob/traefik3/my-compose/whoami/compose.yaml>
 - `.env` (Cloudflare IPs, Authentik config): <https://github.com/brokenscripts/authentik_traefik/blob/traefik3/my-compose/.env>
-- Traefik ACME DNS challenge docs: <https://doc.traefik.io/traefik/https/acme/>
-- Authentik Traefik / forward-auth (proxy provider) docs: <https://docs.goauthentik.io/docs/providers/proxy/>
+- Traefik ACME / certificate-resolver docs: <https://doc.traefik.io/traefik/reference/install-configuration/tls/certificate-resolvers/acme/>
+- Authentik Traefik / forward-auth (proxy provider) docs: <https://docs.goauthentik.io/docs/add-secure-apps/providers/proxy/>
 - Authentik Go client: <https://github.com/goauthentik/client-go> (`goauthentik.io/api/v3 v3.2026050.3`)
 - This repo's provisioner CoreAPI wrappers: `provisioner/internal/authentik/api.go`
 


### PR DESCRIPTION
**README diagram** — the org/group/user diagram rendered org-02 before org-01 (dagre laid out the two disconnected subgraphs in reverse). Replaced with a proper **root → org → group → user tree**; edge-declaration order puts org-01 left of org-02. Verified by the rendered SVG node transforms (org-01 x=292 < org-02 x=910, same rank).

**Traefik spike currency** (from the 3-agent deep-research pass, primary-sourced vs Traefik v3.7.5 + Authentik 2026.5): the doc's approach still holds; fixed the small staleness — `trustForwardHeader` deprecation note (v3.6.14), flagged the guide's Redis as obsolete on 2026.5, corrected the §5 authorization-flow slug, and updated two moved doc URLs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)