### PR TITLE
chore: ship-it review fixes for the forward-auth demo

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -164,9 +164,31 @@ jobs:
       - name: E2E (Authentik via Docker Compose)
         run: make e2e-compose
 
+  # Live forward-auth e2e: stand up Authentik + Traefik + traefik/whoami via
+  # Docker Compose, configure forward-auth with the POC, assert an unauthenticated
+  # whoami request is intercepted (HTTP 302), tear down. Compose-class (same infra
+  # as the e2e job) — gates the forward-auth runtime path the overlay adds.
+  e2e-forward-auth:
+    needs: [changes, build, test]
+    if: ${{ !failure() && !cancelled() && needs.changes.outputs.code == 'true' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    defaults:
+      run:
+        working-directory: provisioner
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      - uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d # v4.2.0
+        with:
+          install: true
+          cache: true
+          working_directory: provisioner
+      - name: E2E forward-auth (Authentik + Traefik + whoami via Docker Compose)
+        run: make e2e-forward-auth
+
   ci-pass:
     if: always()
-    needs: [changes, static-check, build, test, docker, k8s-drift, e2e]
+    needs: [changes, static-check, build, test, docker, k8s-drift, e2e, e2e-forward-auth]
     runs-on: ubuntu-latest
     timeout-minutes: 2
     steps:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -138,7 +138,7 @@ When spawning subagents to work on any of the above, always pass the relevant sk
 
 ## Upgrade Backlog
 
-Deferred / monitor items from `/upgrade-analysis` (2026-06-26). The repo is otherwise fully current — Go 1.26.4, all mise tools at latest, Authentik 2026.5, postgres 18, kubectl 1.36.2 / kind 0.32 / node v1.36.1 (aligned), cloud-provider-kind 0.11.1, all Action SHAs at current major tags; `govulncheck` clean; Renovate alive (automerge on, no Errored branches).
+Deferred / monitor items from `/upgrade-analysis` (verified current 2026-06-27). The repo is otherwise fully current — Go 1.26.4, all mise tools at latest, Authentik 2026.5 (chart 2026.5.3), postgres 18, kubectl 1.36.2 / kind 0.32 / node v1.36.1 (aligned), cloud-provider-kind 0.11.1, all Action SHAs at current major tags; `govulncheck` clean. Renovate is alive but `automerge` is **off** (`renovate.json` → `"automerge": false`) — dependency PRs require a manual merge.
 
 - [ ] **Alternative datastores (CockroachDB / YugabyteDB) — closed, not deferred.** Both were evaluated and removed as non-working (CockroachDB lacks session `pg_advisory_lock()` — [cockroachdb#169981](https://github.com/cockroachdb/cockroach/issues/169981), open; YugabyteDB aborts Authentik's migrations on `YB001` even with every documented mitigation). Full investigation retained in `docs/spikes/authentik-cockroachdb-yugabytedb.md`. PostgreSQL is the only supported backend; no revisit planned unless that analysis's "revisit when…" conditions are met.
 - [ ] **Renovate `lock-file-maintenance`** is in "Awaiting Schedule" (working as designed — periodic `go.sum` refresh); no action needed.

--- a/compose/forward-auth/README.md
+++ b/compose/forward-auth/README.md
@@ -11,7 +11,7 @@ client the core POC uses for users/groups/tokens.
 
 | File | Purpose |
 |------|---------|
-| `docker-compose.forward-auth.yml` | Overlay adding `traefik` (`traefik:v3.7.5`) + `whoami` (`traefik/whoami:v1.11.0`) to the base `authentik` Compose project. |
+| `docker-compose.forward-auth.yml` | Overlay adding `traefik` + `whoami` (`traefik/whoami`) to the base `authentik` Compose project. Image tags are pinned (and Renovate-tracked) in that file — the single source of truth. |
 | `traefik/dynamic.yml` | Traefik dynamic config: the `authentik` forwardAuth middleware + a router proxying the `/outpost.goauthentik.io/` handshake paths back to the Authentik server. |
 
 ## Run it

--- a/provisioner/Makefile
+++ b/provisioner/Makefile
@@ -222,9 +222,10 @@ compose-forward-auth-up: deps
 	@echo "Waiting for default blueprint flows to import (the worker imports them after server-ready)..."
 	@set -a; . $(COMPOSE_DIR)/.env; set +a; \
 	 for i in $$(seq 1 60); do \
-	   if curl -sk -H "Authorization: Bearer $$AUTHENTIK_BOOTSTRAP_TOKEN" \
-	        "https://127.0.0.1:9443/api/v3/flows/instances/?slug=default-provider-authorization-implicit-consent" \
-	        2>/dev/null | grep -q 'default-provider-authorization-implicit-consent'; then echo "blueprint flows ready"; break; fi; \
+	   if printf 'Authorization: Bearer %s' "$$AUTHENTIK_BOOTSTRAP_TOKEN" \
+	        | curl -sk -H @- \
+	            "https://127.0.0.1:9443/api/v3/flows/instances/?slug=default-provider-authorization-implicit-consent" \
+	            2>/dev/null | grep -q 'default-provider-authorization-implicit-consent'; then echo "blueprint flows ready"; break; fi; \
 	   if [ "$$i" = "60" ]; then echo "ERROR: authorization flow not imported within 300s"; $(COMPOSE_FA) logs --tail=40 worker; exit 1; fi; \
 	   sleep 5; \
 	 done
@@ -367,5 +368,7 @@ ci: static-check test build
 
 .PHONY: help deps deps-check check-toolchain-alignment build run test lint lint-docker \
 	vulncheck mermaid-lint compose-lint trivy-fs secrets static-check image-build image-run image-scan k8s-generate k8s-generate-check update clean renovate-validate \
-	compose-up compose-down compose-logs e2e-compose deps-kind kind-create kind-deploy \
+	compose-up compose-down compose-logs \
+	compose-forward-auth-up compose-forward-auth-down e2e-forward-auth \
+	e2e-compose deps-kind kind-create kind-deploy \
 	e2e kind-destroy kind-up kind-down ci


### PR DESCRIPTION
`/ship-it` pass over the just-merged forward-auth feature. Stage 1 (upgrade) found everything already current (Go 1.26.4, chart 2026.5.3, all tool pins + Action SHAs latest, govulncheck clean). Stage 2 review (parallel Makefile/renovate/ci-workflow agents) surfaced these:

## Fixes
- **Makefile (HIGH — secret in argv):** the blueprint-flows poll passed `AUTHENTIK_BOOTSTRAP_TOKEN` via `curl -H "Authorization: Bearer $TOKEN"`, exposing the value in `ps`/`/proc/<pid>/cmdline`. Now fed through stdin (`printf … | curl -H @-`) so it never enters argv. Added the 3 forward-auth targets to `.PHONY`.
- **ci.yml (MEDIUM — coverage gap):** added an `e2e-forward-auth` job. The forward-auth runtime path was only structurally checked (compose-lint); it's Compose-class infra (same as the existing `e2e` job), so it now runs in CI on code changes and is wired into `ci-pass`.
- **CLAUDE.md (LOW — doc/config mismatch):** Upgrade Backlog claimed "automerge on" but `renovate.json` has `"automerge": false`; corrected (dependency PRs merge manually).
- **compose/forward-auth/README.md (LOW — drift):** reference the compose file as the image source of truth instead of restating `traefik`/`whoami` version literals.

renovate.json review: no changes needed — the overlay's `traefik` + `traefik/whoami` are correctly tracked by the native docker-compose manager (verified via `renovate --dry-run=extract`).

## Test plan
- `make ci` green.
- `make e2e-forward-auth` green — verified the stdin secret-fix still authenticates the flows poll (blueprint flows resolved → unauth whoami request → HTTP 302 to Authentik). The new CI `e2e-forward-auth` job exercises this on the PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)