### PR TITLE
docs: correct e2e-forward-auth description (follows redirect to 200 login)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,7 +55,7 @@ make compose-up / compose-down  # bring the Compose Authentik stack up / tear it
 # --- Forward-auth demo (Traefik + traefik/whoami gated by Authentik) ---
 make compose-forward-auth-up    # base stack + Traefik + whoami, then configure forward-auth (browse https://whoami.127-0-0-1.sslip.io)
 make compose-forward-auth-down  # tear the forward-auth demo down (removes volumes)
-make e2e-forward-auth           # up -> configure -> assert unauth whoami request -> HTTP 302 -> down
+make e2e-forward-auth           # up -> configure -> follow redirect -> assert Authentik login reachable (HTTP 200) -> down
 
 make renovate-validate          # validate renovate.json
 

--- a/compose/forward-auth/README.md
+++ b/compose/forward-auth/README.md
@@ -22,7 +22,7 @@ From `provisioner/`:
 make compose-forward-auth-up     # base stack + traefik + whoami, then configure forward-auth
 # browse https://whoami.127-0-0-1.sslip.io  (accept the self-signed cert)
 make compose-forward-auth-down   # tear down + remove volumes
-make e2e-forward-auth            # up -> configure -> assert unauth request 302s to login -> down
+make e2e-forward-auth            # up -> configure -> follow the redirect -> assert the Authentik login is reachable (HTTP 200) -> down
 ```
 
 `make compose-forward-auth-up` runs the provisioner with


### PR DESCRIPTION
`/ship-it` docs pass. Stage 1 found everything current (no open Renovate PRs, all tool pins latest, govulncheck clean); Stage 2 was inline-verified (a full review ran this session for #43/#44; the only change is doc wording with zero convention surface); Stage 3 `make ci` green.

Two help-text lines still described the pre-#44 e2e behavior ("assert unauth request 302s"). Since #44, `make e2e-forward-auth` follows the redirect and asserts the Authentik login is reachable (HTTP 200) — corrected the lines in `CLAUDE.md` and `compose/forward-auth/README.md` to match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)