### PR TITLE
fix: resolve gitleaks via mise before leaving provisioner/ (unblocks mise-action v4.2.1)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
       docs: ${{ steps.filter.outputs.docs }}
       k8s: ${{ steps.filter.outputs.k8s }}
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706 # v4
         id: filter
         with:
@@ -66,8 +66,8 @@ jobs:
       run:
         working-directory: provisioner
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
-      - uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d # v4.2.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: jdx/mise-action@dad1bfd3df957f44999b559dd69dc1671cb4e9ea # v4.2.1
         with:
           install: true
           cache: true
@@ -84,8 +84,8 @@ jobs:
       run:
         working-directory: provisioner
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
-      - uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d # v4.2.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: jdx/mise-action@dad1bfd3df957f44999b559dd69dc1671cb4e9ea # v4.2.1
         with:
           install: true
           cache: true
@@ -102,8 +102,8 @@ jobs:
       run:
         working-directory: provisioner
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
-      - uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d # v4.2.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: jdx/mise-action@dad1bfd3df957f44999b559dd69dc1671cb4e9ea # v4.2.1
         with:
           install: true
           cache: true
@@ -125,8 +125,8 @@ jobs:
       run:
         working-directory: provisioner
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
-      - uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d # v4.2.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: jdx/mise-action@dad1bfd3df957f44999b559dd69dc1671cb4e9ea # v4.2.1
         with:
           install: true
           cache: true
@@ -147,8 +147,8 @@ jobs:
       run:
         working-directory: provisioner
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
-      - uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d # v4.2.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: jdx/mise-action@dad1bfd3df957f44999b559dd69dc1671cb4e9ea # v4.2.1
         with:
           install: true
           cache: true
@@ -168,8 +168,8 @@ jobs:
       run:
         working-directory: provisioner
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
-      - uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d # v4.2.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: jdx/mise-action@dad1bfd3df957f44999b559dd69dc1671cb4e9ea # v4.2.1
         with:
           install: true
           cache: true
@@ -189,8 +189,8 @@ jobs:
       run:
         working-directory: provisioner
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
-      - uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d # v4.2.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: jdx/mise-action@dad1bfd3df957f44999b559dd69dc1671cb4e9ea # v4.2.1
         with:
           install: true
           cache: true
@@ -213,8 +213,8 @@ jobs:
       run:
         working-directory: provisioner
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
-      - uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d # v4.2.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: jdx/mise-action@dad1bfd3df957f44999b559dd69dc1671cb4e9ea # v4.2.1
         with:
           install: true
           cache: true
@@ -239,8 +239,8 @@ jobs:
       run:
         working-directory: provisioner
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
-      - uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d # v4.2.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: jdx/mise-action@dad1bfd3df957f44999b559dd69dc1671cb4e9ea # v4.2.1
         with:
           install: true
           cache: true
@@ -261,7 +261,7 @@ jobs:
       run:
         working-directory: provisioner
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - name: Lint README Mermaid diagrams
         run: make mermaid-lint
 
@@ -290,7 +290,7 @@ jobs:
       contents: read
       packages: write
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - name: Log in to GHCR
         uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
         with:

--- a/provisioner/Makefile
+++ b/provisioner/Makefile
@@ -130,8 +130,19 @@ cve-scan: vulncheck trivy-fs
 	@echo "CVE scan passed."
 
 #secrets: @ Scan the working tree for leaked secrets (gitleaks; demo creds allowlisted in .gitleaks.toml)
+# The scan MUST run with cwd = repo root: gitleaks reports finding paths relative to cwd, and
+# .gitleaks.toml anchors its allowlist at the scan root (`^k8s/.+\.ya?ml$`, `(^|/)\.env…`).
+# Running it from here with `--source ..` instead yields `../k8s/…`, which those anchors miss —
+# measured: 4 intentional demo credentials resurface as "leaks".
+# But mise's config lives HERE (provisioner/.mise.toml; there is no root-level mise config), so
+# the binary must be resolved BEFORE leaving this directory. Once mise-action puts SHIMS on PATH
+# (v4.2.1+, upstream b107e20a "exclude PATH from environment export"), a shim invoked from the
+# repo root cannot resolve a version -> `mise ERROR No version is set for shim: gitleaks`.
+# `mise which` prints the absolute install path, which is cwd-independent.
 secrets: deps
-	@cd .. && gitleaks detect --no-git --source . -c .gitleaks.toml --redact --no-banner
+	@GITLEAKS="$$(mise which gitleaks 2>/dev/null || command -v gitleaks)"; \
+	[ -x "$$GITLEAKS" ] || { echo "ERROR: gitleaks not found; run 'make deps'"; exit 1; }; \
+	cd .. && "$$GITLEAKS" detect --no-git --source . -c .gitleaks.toml --redact --no-banner
 
 #mermaid-lint: @ Validate README/CLAUDE Mermaid diagrams render cleanly (minlag/mermaid-cli)
 mermaid-lint:


### PR DESCRIPTION
Supersedes #70 — carries its **entire** diff (verified identical) plus the Makefile fix that bump requires.

## Why one PR

On the old pin the bug **cannot manifest**, so a fix-only PR would go green having never exercised the fix. Bump and fix ship together.

## Root cause (measured)

The `jdx/mise-action` v4.2.0 → v4.2.1 range contains upstream commit `b107e20a` *"fix: exclude PATH from environment export"*.

| version | what lands on PATH | cwd-sensitive? |
|---|---|---|
| v4.2.0 | `mise env`'s PATH — absolute **install** dirs | no |
| v4.2.1 | the mise **shims** dir | **yes** — a shim resolves the version from the config applying to the *current* directory |

The `secrets` target ran `cd .. && gitleaks …`. mise's config is `provisioner/.mise.toml` and there is **no root-level mise config**, so after `cd ..` the shim had nothing to resolve against:

```
mise ERROR No version is set for shim: gitleaks
make: *** [Makefile:134: secrets] Error 1
```

The `cd ..` has been latent since it was written — the bump only exposed it. Pinning mise-action back would hide a real defect, so it isn't done here.

## Why the `cd` is kept

The obvious fix — drop the `cd`, pass `--source ..` — is **refuted by measurement**. gitleaks reports finding paths relative to **cwd**, and `.gitleaks.toml` anchors its allowlist at the scan root (`^k8s/.+\.ya?ml$`, `(^|/)\.env(\.example)?$`). From `provisioner/` those become `../k8s/…`, the anchors miss, and **4 intentional demo credentials resurface as leaks**.

So the scan keeps running with cwd = repo root; only the *binary resolution* moves ahead of the `cd`. Scan coverage is unchanged by construction.

## Blast radius

Exactly one line. The repo has two `cd ..` occurrences; the other (`mermaid-lint`) runs `grep`, not a mise tool. `trivy-fs` already uses the correct shape — it passes `..` as an argument and never `cd`s.

## Verification

Under a CI-faithful PATH (mise shims present, install dirs absent):

- **RED before** — gitleaks from the repo root → `No version is set for shim: gitleaks`
- **GREEN after** — `make secrets` → `no leaks found`, exit 0
- **Gate still enforces** — a planted random high-entropy `ghp_` token in a non-allowlisted file → `leaks found: 1`, exit 2 (then removed). A low-entropy placeholder would have been entropy-filtered and false-passed.
- `make static-check` end-to-end → `Static check passed.`

The authoritative check is this PR's CI, since that is the only place mise-action v4.2.1's shim PATH is actually in play.

## Note

Do **not** close #70 by hand — closing a Renovate PR adds the update to its ignore list. Once this lands, `main` carries both SHAs and Renovate closes #70 itself.
