### PR TITLE
fix(security): secrets gate was passing over ~11% of the repo unread, plus adversary-driven CI/Makefile fixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,7 +118,7 @@ jobs:
   # on every PR; this builds + scans the actual image before a tag ships.
   docker:
     needs: [changes, static-check]
-    if: ${{ !failure() && !cancelled() && startsWith(github.ref, 'refs/tags/') }}
+    if: ${{ !failure() && !cancelled() && (startsWith(github.ref, 'refs/tags/') || github.event_name == 'workflow_dispatch') }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
     defaults:
@@ -140,7 +140,7 @@ jobs:
   # deps + the Go toolchain current between releases.
   security:
     needs: [changes, static-check]
-    if: ${{ !failure() && !cancelled() && startsWith(github.ref, 'refs/tags/') }}
+    if: ${{ !failure() && !cancelled() && (startsWith(github.ref, 'refs/tags/') || github.event_name == 'workflow_dispatch') }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
     defaults:
@@ -159,9 +159,13 @@ jobs:
   # Drift gate: the committed k8s/postgresql manifest is generated from the pinned
   # Authentik Helm chart + values.yml. Fail if it's stale (e.g. a Renovate chart
   # bump without a regen). helm-only (template + diff) — no cluster needed.
+  # Also runs on a TAG: paths-filter diffs against the default branch, so on a tag
+  # pointing at main HEAD it reports k8s == 'false' and this gate would be skipped —
+  # letting a release ship with the committed manifest stale against the pinned chart.
+  # `publish` gates on it explicitly for the same reason.
   k8s-drift:
     needs: [changes]
-    if: ${{ !failure() && !cancelled() && needs.changes.outputs.k8s == 'true' }}
+    if: ${{ !failure() && !cancelled() && (needs.changes.outputs.k8s == 'true' || startsWith(github.ref, 'refs/tags/') || github.event_name == 'workflow_dispatch') }}
     runs-on: ubuntu-latest
     timeout-minutes: 5
     defaults:
@@ -285,7 +289,7 @@ jobs:
   # GHCR auth uses the built-in GITHUB_TOKEN (no operator secret).
   # Cosign signing / richer SBOM attestation are a `/harden-image-pipeline` follow-up.
   publish:
-    needs: [changes, static-check, build, test, docker, security, e2e, e2e-kind, e2e-forward-auth-browser]
+    needs: [changes, static-check, build, test, docker, security, k8s-drift, e2e, e2e-kind, e2e-forward-auth-browser]
     # Gate on EXPLICIT success of every prerequisite, NOT `!failure()`. A SKIPPED
     # need (build/test/docker/security skip when static-check fails/flakes on the
     # tagged commit) is neither `failure` nor `cancelled`, and `failure()` does NOT
@@ -299,6 +303,7 @@ jobs:
           && needs.test.result == 'success'
           && needs.docker.result == 'success'
           && needs.security.result == 'success'
+          && needs.k8s-drift.result == 'success'
           && needs.e2e.result == 'success'
           && needs.e2e-kind.result == 'success'
           && needs.e2e-forward-auth-browser.result == 'success' }}

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,10 @@
 */.env
 bin/
 !.env.example
+# Claude Code local state: settings.local.json holds machine-local permission
+# approvals, and worktrees/ holds full nested COPIES of this repo created for
+# isolated subagents. Neither belongs in git — and the nested copies would
+# otherwise be walked by tree-scanning gates (`make secrets` runs gitleaks with
+# --no-git, i.e. over the working tree), inflating scans and reporting findings
+# from a duplicate of the repo.
+.claude/

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,26 +1,42 @@
 # gitleaks config for the `secrets` Make target (scans the CURRENT working tree:
-# `gitleaks detect --no-git`). This repo is a POC whose .env.example / k8s
-# manifests / main.go fallback consts intentionally ship DEMO credentials
-# (documented as "rotate for real use"). They are allowlisted below so the gate
-# still catches a REAL accidental leak anywhere else (code, scripts, compose).
+# `gitleaks detect --no-git`). This POC intentionally ships DEMO credentials in
+# .env.example, the k8s manifests, and main.go fallback consts (documented as
+# "rotate for real use").
+#
+# They are pinned BY VALUE, never by whole-file path. That distinction is
+# load-bearing. A `paths` entry is a WHOLE-FILE SKIP -- gitleaks never opens the
+# file. This config previously skipped every k8s/**.ya?ml and every .env*, and a
+# RED-proof showed the gate reporting "no leaks found" (rc=0) with freshly planted
+# real-format GitHub PATs sitting in those files. ~10% of the repo (~25 KB,
+# including every committed manifest) was never read, and the "bytes scanned"
+# figure could not move when a secret was added there -- a gate that passed by not
+# looking. Value-pinning keeps the known demo credentials quiet while the files
+# themselves stay scanned.
+#
+# Do NOT re-add `paths` to silence a new finding: pin the VALUE, or fix the leak.
 [extend]
 useDefault = true
 
-[allowlist]
-description = "Intentional committed demo credentials (rotate for real deployments)"
-# Whole-file demo-credential sources:
-#  - .env / .env.example: the committed config source-of-truth + local overrides
-#  - k8s/**.y(a)ml: Helm-generated Authentik manifests; the only 'secrets' are the
-#    demo `authentik` Secret and base64 of non-secrets (service names, db names)
-paths = [
-    '''(^|/)\.env(\.example)?$''',
-    '''^k8s/.+\.ya?ml$''',
-]
-# main.go ships the same demo tokens as fallback defaults (mirroring .env.example);
-# allowlist the exact values so the rest of the Go code is still scanned.
+[[allowlists]]
+description = "Intentional committed demo credentials -- pinned by VALUE so the files stay scanned"
+regexTarget = "secret"
 regexes = [
     '''NoMlxBQuYgfu3j19ygGqhjXenAjrJgOfN5naqmSDBUhdLjYqHKze7yyzY07H''',
     '''ZId4CDEtmHbnuxkJH2ehUzHgYeTmOansuCO0JsTTsZnYB1z9N0WoAutpyH4i''',
     '''e3qVF1uGTL5DKjglvMKpDYk60X7s89jnbNh9nPEpFYzSgoOHYDSMi0xxYhYr''',
     '''svkH90FMYlnXPA5JHxePVQkozTjXReT6rsdQ2BXedwI5mtrFYR5mfrunMt4B''',
+    '''ZnIogyvvZGZRKPNwYjYLNbfJGMyAIi4fYMLvERevXshb81f5X3''',
+    '''VGhpc0lzTm90QVNlY3VyZVBhc3N3b3Jk''',
+    '''UGxlYXNlR2VuZXJhdGVBNTBDaGFyS2V5''',
+    '''8a8fbfa0415ad55b7e7bb43916ce5552ccca1b8877057d348017acf03f11dbba''',
+]
+
+# The Helm-rendered pod templates carry `checksum/secret: <sha256>` annotations.
+# That is a HASH OF the rendered Secret (used to force a rollout), not a credential.
+# Suppressed by LINE so the rest of the manifest stays scanned.
+[[allowlists]]
+description = "Helm checksum/secret annotation: a sha of the rendered Secret, not a credential"
+regexTarget = "line"
+regexes = [
+    '''checksum/secret:''',
 ]

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,7 +66,8 @@ make -C provisioner kind-up      # Kubernetes: KinD + cloud-provider-kind, appli
 cd provisioner
 cp .env.example .env   # one-time: per-dev config (gitignored); main.go also has the same fallbacks
 make deps     # install mise (if missing) + pinned Go/golangci-lint/govulncheck/hadolint/kind/kubectl
-make ci       # full local pipeline: static-check (align+lint+hadolint+mermaid+compose+vulncheck+trivy-fs+secrets) + test + build
+make ci       # full local pipeline: static-check (align+lint+hadolint+mermaid+compose+secrets) + test + build
+make cve-scan # govulncheck + trivy fs — NOT part of static-check/ci; run before cutting a release
 make run      # run the POC against a running Authentik (sources .env.example then .env)
 make test     # go test ./...  (unit + hermetic httptest contract tests)
 make image-build / image-run   # build/run the POC container (config via --env-file)

--- a/README.md
+++ b/README.md
@@ -289,7 +289,8 @@ Run `make help` for the full list. Common targets:
 | `make lint-docker` | Lint the Dockerfile with hadolint |
 | `make vulncheck` | Scan dependencies with govulncheck |
 | `make compose-lint` | Lint the Compose file with dclint (rules in `.dclintrc.yaml`) |
-| `make static-check` | Composite gate: alignment + lint + hadolint + mermaid + compose + vulncheck + trivy-fs + secrets |
+| `make static-check` | Composite gate: alignment + lint + hadolint + mermaid + compose + secrets |
+| `make cve-scan` | govulncheck + Trivy filesystem scan — **not** in `static-check`; run before cutting a release |
 | `make image-build` / `make image-run` | Build / run the distroless container image |
 | `make image-scan` | Build the image and scan it for HIGH/CRITICAL CVEs (Trivy) |
 | `make compose-up` / `make compose-down` | Start / stop the Authentik Compose stack |

--- a/provisioner/Makefile
+++ b/provisioner/Makefile
@@ -141,7 +141,8 @@ cve-scan: vulncheck trivy-fs
 # `mise which` prints the absolute install path, which is cwd-independent.
 secrets: deps
 	@GITLEAKS="$$(mise which gitleaks 2>/dev/null || command -v gitleaks)"; \
-	[ -x "$$GITLEAKS" ] || { echo "ERROR: gitleaks not found; run 'make deps'"; exit 1; }; \
+	case "$$GITLEAKS" in */mise/shims/*) GITLEAKS="";; esac; \
+	[ -x "$$GITLEAKS" ] || { echo "ERROR: could not resolve a real gitleaks binary (a mise SHIM is not usable here — it is cwd-dependent); run 'make deps'"; exit 1; }; \
 	cd .. && "$$GITLEAKS" detect --no-git --source . -c .gitleaks.toml --redact --no-banner
 
 #mermaid-lint: @ Validate README/CLAUDE Mermaid diagrams render cleanly (minlag/mermaid-cli)
@@ -312,7 +313,8 @@ e2e-forward-auth: deps
 # relative paths are correct. Do NOT flatten it back to a bare `cd`.
 e2e-forward-auth-browser: deps
 	@NODE_BIN="$$(mise which node 2>/dev/null || command -v node)"; \
-	[ -x "$$NODE_BIN" ] || { echo "node missing — run 'make deps' (node is pinned in .mise.toml)"; exit 1; }; \
+	case "$$NODE_BIN" in */mise/shims/*) NODE_BIN="";; esac; \
+	[ -x "$$NODE_BIN" ] || { echo "could not resolve a real node binary (a mise SHIM is not usable here — it is cwd-dependent, and prepending the shims dir is a no-op); run 'make deps'"; exit 1; }; \
 	PATH="$$(dirname "$$NODE_BIN"):$$PATH"; export PATH; \
 	trap '$(COMPOSE_FA) down -v >/dev/null 2>&1 || true' EXIT INT TERM; \
 	$(MAKE) --no-print-directory compose-forward-auth-up && { \

--- a/provisioner/Makefile
+++ b/provisioner/Makefile
@@ -299,9 +299,17 @@ e2e-forward-auth: deps
 # `secrets` target broke the same way.
 # Fix: resolve node's real bin dir BEFORE leaving and prepend it to PATH, so node AND the
 # npm/npx that internally re-invoke it all resolve cwd-independently.
-# NOTE: this is defensive, not a repair of an observed break — CI currently passes here
-# (see the PR), so no RED was demonstrated for this target; the guard/use mismatch is the
-# defect being fixed.
+# NOTE: the node resolution above is defensive — CI passes this target today, so no RED was
+# demonstrated for it; the guard/use mismatch is the defect being fixed.
+#
+# The `( ... )` subshell around the cd, by contrast, fixes a MEASURED leak. The EXIT trap
+# runs in THIS shell, and a bare `cd $(BROWSER_E2E_DIR)` left that shell in e2e/browser — so
+# the trap's `$(COMPOSE_FA)` relative paths resolved to e2e/compose/docker-compose.yml
+# (nonexistent), `docker compose down` failed, and `|| true` swallowed it. Every run leaked
+# the whole stack (5 containers + volumes) silently. Verified: running the trap's exact
+# command from e2e/browser errors with "open .../e2e/compose/docker-compose.yml: no such
+# file or directory". The subshell keeps the trap's cwd at provisioner/, where those
+# relative paths are correct. Do NOT flatten it back to a bare `cd`.
 e2e-forward-auth-browser: deps
 	@NODE_BIN="$$(mise which node 2>/dev/null || command -v node)"; \
 	[ -x "$$NODE_BIN" ] || { echo "node missing — run 'make deps' (node is pinned in .mise.toml)"; exit 1; }; \
@@ -309,9 +317,9 @@ e2e-forward-auth-browser: deps
 	trap '$(COMPOSE_FA) down -v >/dev/null 2>&1 || true' EXIT INT TERM; \
 	$(MAKE) --no-print-directory compose-forward-auth-up && { \
 	  set -a; . $(COMPOSE_DIR)/.env; set +a; \
-	  cd $(BROWSER_E2E_DIR) && npm ci && npx playwright install $(PLAYWRIGHT_BROWSER_DEPS) chromium && \
-	  APP_URL=$(WHOAMI_URL)/ AK_ADMIN_USER=$(AK_ADMIN_USER) AK_ADMIN_PASS="$$AUTHENTIK_BOOTSTRAP_PASSWORD" \
-	  npx playwright test; \
+	  ( cd $(BROWSER_E2E_DIR) && npm ci && npx playwright install $(PLAYWRIGHT_BROWSER_DEPS) chromium && \
+	    APP_URL=$(WHOAMI_URL)/ AK_ADMIN_USER=$(AK_ADMIN_USER) AK_ADMIN_PASS="$$AUTHENTIK_BOOTSTRAP_PASSWORD" \
+	    npx playwright test ); \
 	}
 
 # ---------------------------------------------------------------------------

--- a/provisioner/Makefile
+++ b/provisioner/Makefile
@@ -290,15 +290,29 @@ e2e-forward-auth: deps
 	 }
 
 #e2e-forward-auth-browser: @ E2E: real browser completes the Authentik login -> whoami serves identity headers -> down (Playwright)
+# node/npm/npx are mise-managed (node is pinned in .mise.toml, which lives HERE) but are
+# invoked after `cd $(BROWSER_E2E_DIR)` — a directory OUTSIDE this one, with no mise config
+# above it. So the old `command -v node` guard checked node HERE and the recipe used node
+# THERE: a guard that cannot vouch for the thing it guards. Since mise-action v4.2.1 puts
+# SHIMS on PATH (upstream b107e20a stopped exporting mise env's PATH), a shim resolves its
+# version from the config applying to the CURRENT directory — which is why the sibling
+# `secrets` target broke the same way.
+# Fix: resolve node's real bin dir BEFORE leaving and prepend it to PATH, so node AND the
+# npm/npx that internally re-invoke it all resolve cwd-independently.
+# NOTE: this is defensive, not a repair of an observed break — CI currently passes here
+# (see the PR), so no RED was demonstrated for this target; the guard/use mismatch is the
+# defect being fixed.
 e2e-forward-auth-browser: deps
-	@command -v node >/dev/null 2>&1 || { echo "node missing — run 'make deps' (node is pinned in .mise.toml)"; exit 1; }
-	@trap '$(COMPOSE_FA) down -v >/dev/null 2>&1 || true' EXIT INT TERM; \
-	 $(MAKE) --no-print-directory compose-forward-auth-up && { \
-	   set -a; . $(COMPOSE_DIR)/.env; set +a; \
-	   cd $(BROWSER_E2E_DIR) && npm ci && npx playwright install $(PLAYWRIGHT_BROWSER_DEPS) chromium && \
-	   APP_URL=$(WHOAMI_URL)/ AK_ADMIN_USER=$(AK_ADMIN_USER) AK_ADMIN_PASS="$$AUTHENTIK_BOOTSTRAP_PASSWORD" \
-	   npx playwright test; \
-	 }
+	@NODE_BIN="$$(mise which node 2>/dev/null || command -v node)"; \
+	[ -x "$$NODE_BIN" ] || { echo "node missing — run 'make deps' (node is pinned in .mise.toml)"; exit 1; }; \
+	PATH="$$(dirname "$$NODE_BIN"):$$PATH"; export PATH; \
+	trap '$(COMPOSE_FA) down -v >/dev/null 2>&1 || true' EXIT INT TERM; \
+	$(MAKE) --no-print-directory compose-forward-auth-up && { \
+	  set -a; . $(COMPOSE_DIR)/.env; set +a; \
+	  cd $(BROWSER_E2E_DIR) && npm ci && npx playwright install $(PLAYWRIGHT_BROWSER_DEPS) chromium && \
+	  APP_URL=$(WHOAMI_URL)/ AK_ADMIN_USER=$(AK_ADMIN_USER) AK_ADMIN_PASS="$$AUTHENTIK_BOOTSTRAP_PASSWORD" \
+	  npx playwright test; \
+	}
 
 # ---------------------------------------------------------------------------
 # End-to-end test (build-tagged Go test against a live Authentik)


### PR DESCRIPTION
Two adversary reviews (shell/Makefile/CI, and secrets/CVE) refuted several of my premises from earlier in this session. This branch carries the fixes. **The headline is a CRITICAL hole in the secrets gate that predates all of it.**

## CRITICAL — `make secrets` exited 0 with real credentials in the tree

`.gitleaks.toml`'s `paths` entry is a **whole-file skip**, not a finding filter — gitleaks never opened any `k8s/**.ya?ml` or any `.env*`. Planting random high-entropy real-format GitHub PATs in those files produced `scanned ~229079 bytes … no leaks found`, **rc=0**. Reproduced independently before fixing.

It also refuted the certification I shipped with the previous commit: I verified "coverage unchanged" by comparing **bytes scanned**, a number that is *structurally incapable of moving* when a secret lands in a file the scanner never reads. A proxy, presented as verification.

**Fix:** pin the intentional demo credentials **by value**; suppress the Helm `checksum/secret:` annotation (a SHA of the rendered Secret, not a credential) **by line**. No whole-file skips remain.

RED/GREEN proven both directions on a throwaway copy:

| | old config | new config |
|---|---|---|
| clean tree | 229,079 B · rc 0 | **254,866 B** · rc 0 |
| 3 canaries in previously-blind files | 0 caught · **rc 0** | **3/3 caught** · rc 1 |

Canaries in `k8s/postgresql/authentik-postgresql.yml`, `compose/.env.example`, `compose/.env` — **+25,787 bytes (~11% of the repo) now actually read.**

## The rest

- **My `command -v` fallbacks resolved to a mise SHIM.** `Makefile:58` exports PATH with the shims dir *first* for every recipe, and `[ -x ]` passes a shim — so the fallback re-opened the exact hole the change closes. Both targets now reject shims. Measured aggravator: on mise 2026.7.11 a shim outside its config dir doesn't error, it **silently resolves a different version** (`golangci-lint` 2.11.4 against a 2.12.2 pin) — a silent wrong-instrument in a security scanner.
- **`k8s-drift` had no tag arm and didn't gate `publish`** — `paths-filter` reports `k8s == 'false'` for a tag at `main` HEAD, so a release could ship with the committed manifest stale against the pinned chart. Both added.
- **`docker`/`security` lacked the `workflow_dispatch` arm** the e2e jobs have, so there was no way to exercise the image scan or CVE scan before a tag.
- **Docs claimed `static-check` runs `vulncheck + trivy-fs`.** It doesn't — corrected in README + CLAUDE.md, with `cve-scan` listed separately.
- Earlier on this branch: node resolved cwd-independently for the browser e2e (the old `command -v node` guard ran in `provisioner/` while `npm` ran in `e2e/browser/`), and a **measured container leak** fixed — the EXIT trap ran after a bare `cd`, so its relative compose paths resolved wrong, `docker compose down` failed, `|| true` swallowed it, and every run leaked 5 containers + volumes while exiting 0.

## Verification

- `make static-check` → passed (255,596 bytes scanned, no leaks).
- `make e2e-forward-auth-browser` → real Chromium login, identity headers served; `docker ps` clean afterwards (the leak fix, RED→GREEN).
- ⚠️ **This PR's own CI cannot exercise the browser e2e** — the tag-only change means it skips on `pull_request`. So `ci-pass` green here is *not* evidence for the recipe this branch edits. A `workflow_dispatch` run on this branch is the gating evidence; merge only when its `e2e-forward-auth-browser` is green.

## Known, not addressed — needs an owner decision

The repo has **zero tags**, so every tag-only job (`docker`, `security`, all three e2e) currently runs **nowhere**. `main` is clean today (both CVE gates run by hand), but nothing reports when that stops being true. Options: a weekly `schedule:` arm on `docker`/`security`, or putting `security` back on the PR path.

Also out of scope: `publish` rebuilds the image rather than pushing the bytes `docker` scanned, and there is no git-**history** secret scan (only `--no-git`), so a credential in any past commit is invisible.
