### PR TITLE
fix(renovate): drop the Go 1.27 cap (wrong premise) and gate renovate.json

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,7 @@ jobs:
               - 'e2e/**'
               - '.dclintrc.yaml'
               - '.gitleaks.toml'
+              - 'renovate.json'
             docs:
               - 'README.md'
             k8s:

--- a/provisioner/Makefile
+++ b/provisioner/Makefile
@@ -173,7 +173,7 @@ compose-lint:
 	@echo "compose-lint: OK"
 
 #static-check: @ Composite quality gate (alignment + lint + hadolint + mermaid + compose + secrets). CVE scans (vulncheck + trivy-fs) run on release tags only — see cve-scan.
-static-check: deps check-toolchain-alignment lint lint-docker mermaid-lint compose-lint secrets
+static-check: deps check-toolchain-alignment lint lint-docker mermaid-lint compose-lint renovate-validate secrets
 	@echo "Static check passed."
 
 #image-build: @ Build the POC container image

--- a/renovate.json
+++ b/renovate.json
@@ -145,12 +145,6 @@
       "description": "Keep golangci-lint in the `go toolchain` group. golangci-lint refuses to run when the Go version it was BUILT with is older than the Go version it is asked to target, so the two are version-locked and must land as one PR — a split produces two individually-unmergeable PRs (see the allowedVersions hold below).",
       "matchPackageNames": ["golangci/golangci-lint"],
       "groupName": "go toolchain"
-    },
-    {
-      "description": "HOLD the Go toolchain below 1.27 until golangci-lint ships a release built with Go 1.27. golangci-lint aborts with \"the Go language version (go1.26) used to build golangci-lint is lower than the targeted Go version (1.27.1)\", which reddens static-check, so a Go 1.27 PR can never go green on its own. Measured 2026-09-09: the newest release v2.13.2 (2026-08-27) still declares `go 1.26.0` in its go.mod. REMOVE THIS CAP once a golangci-lint release is built with Go 1.27+ — the `go toolchain` group above then lands both together. This is a hold with an expiry condition, not a permanent pin.",
-      "matchManagers": ["gomod", "mise", "dockerfile"],
-      "matchDepNames": ["go", "golang"],
-      "allowedVersions": "<1.27.0"
     }
   ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -100,10 +100,10 @@
       "minimumReleaseAge": "3 days"
     },
     {
-      "description": "Lock kubectl to the cluster node's minor line (kindest/node v1.36.x). CI runs no live e2e, so it cannot catch kubectl<->apiserver skew — this constraint is the only guard. Matches by packageName (the mise aqua depName is `aqua:kubernetes/kubectl`, but packageName resolves to `kubernetes/kubectl`). Bump it together with kind + kindest/node when the cluster moves to a new minor.",
+      "description": "Lock kubectl to the cluster node's minor line (kindest/node v1.37.x). CI runs no live e2e, so it cannot catch kubectl<->apiserver skew — this constraint is the only guard. Matches by packageName (the mise aqua depName is `aqua:kubernetes/kubectl`, but packageName resolves to `kubernetes/kubectl`). Bump it together with kind + kindest/node when the cluster moves to a new minor.",
       "matchManagers": ["mise"],
       "matchPackageNames": ["kubernetes/kubectl"],
-      "allowedVersions": "/^1\\.36\\./"
+      "allowedVersions": "/^1\\.37\\./"
     },
     {
       "description": "Custom.regex docker pins (env-file AUTHENTIK_TAG, Makefile cloud-provider-kind) are bare tags/versions, not pullable image refs, so docker:pinDigests cannot render a write for them — disable it. Production-runtime pins via the built-in dockerfile/docker-compose/kubernetes managers keep their digests.",


### PR DESCRIPTION
Corrects a mistake I introduced in #100, and closes the hole that let #100 merge unverified.

## 1. The Go 1.27 cap was based on a measurement error — reverted

I read golangci-lint's `go.mod` **language directive** (`go 1.26.0`) and concluded v2.13.2 could not target Go 1.27. golangci-lint's check actually reads `debug.BuildInfo.GoVersion` — the **build toolchain**. Measured on the release binaries aqua installs (`go version -m`):

| release binary | built with | can target Go 1.27.1? |
|---|---|---|
| **v2.12.2** — main's pin, and what PR #88 actually installed | `go1.26.2` | no → emits the exact error #88 reported |
| **v2.13.2** — the pending bump | **`go1.27.0`** | **yes** |

So the cap's stated removal condition was **already satisfied when it was written** — a hold born stale. Worse, it suppressed Go *patch* releases, which carry stdlib CVEs, while `vulncheck`/`trivy` are tag-only and would never flag a stale toolchain on the PR path.

**The correct fix for the Go bump is ordering, not a cap:** land the golangci-lint bump first, then the Go bump goes green unaided.

The `golangci-lint` ↔ `go toolchain` **group is kept** — the two genuinely are version-locked, and the group is what stops the bot splitting them into two individually-unmergeable PRs again.

## 2. `renovate.json` had no gate — #100 merged having run zero jobs

Measured on #100: `static-check`, `build`, `test`, `k8s-drift` all `skipping`, and `ci-pass` **pass** — because `ci-pass` treats skipped as passed and `renovate.json` is in no paths-filter. So a change to the file governing the entire dependency-automation posture merged with nothing verifying it.

- `renovate.json` added to the `code` filter.
- `renovate-validate` added as a `static-check` prerequisite (the target already existed at Makefile:202 but was wired into no job).

## Test plan

- [x] `make static-check` green on this branch (`Config validated successfully`, `Static check passed.`)
- [x] **RED-proven**: with `"automerge": "yes-please"`, `static-check` exits **2** (`ERROR: Found errors in configuration`); restored → exits **0**
- [x] `main` verified drift-clean after the #75/#90 merges (`k8s-generate-check: in sync`)
- [ ] After merge: land the golangci-lint bump, then confirm the Go bump goes green on its own

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018T6h3TqYiqMMV6AMXC3VmP

## 3. Move the kubectl cap to the 1.37 node line (added)

#97 bumps `kindest/node` v1.36.1 → v1.37.0, but kubectl is held at 1.36.2 by `allowedVersions: "/^1\.36\./"` — whose own comment reads *"Lock kubectl to the cluster node's minor line (kindest/node v1.36.x) … **this constraint is the only guard**"* and *"Bump it together with kind + kindest/node when the cluster moves to a new minor."*

Merging #97 without this makes that comment false. A 1.36 client against a 1.37 apiserver is inside the supported ±1 skew, so nothing breaks today — but `e2e-kind` is tag-only, so no PR-path job can see the skew, and the **next** node bump takes it to 1.36 vs 1.38, which is unsupported, with the guard silently wrong.

This is the "bump it together" that rule asks for.
